### PR TITLE
Task/schematemplate fix

### DIFF
--- a/ingest/template/schema_parser.py
+++ b/ingest/template/schema_parser.py
@@ -1,11 +1,14 @@
 import json
 
 import jsonref
+from jsonref import JsonLoader
 
 from .descriptor import ComplexPropertyDescriptor
 
 
-class SchemaParser():
+class SchemaParser:
+    json_loader = JsonLoader()
+
     def __init__(self, json_schema,
                  ignored_properties=["required_properties", "describedBy", "schema_version", "schema_type",
                                      "provenance"]):
@@ -27,8 +30,8 @@ class SchemaParser():
         """
 
         # Use jsonref to resolve all $refs in JSON
-        metadata_schema_data = jsonref.loads(json.dumps(json_schema))
 
+        metadata_schema_data = jsonref.loads(json.dumps(json_schema), loader=SchemaParser.json_loader)
         self._schema_descriptor = ComplexPropertyDescriptor(metadata_schema_data)
 
     @property

--- a/ingest/template/schema_template.py
+++ b/ingest/template/schema_template.py
@@ -88,7 +88,7 @@ class SchemaTemplate():
         if not self.json_schemas:
             self.json_schemas = self._get_json_objs_from_metadata_schema_urls()
         else:
-            self.metadata_schema_urls = [schema["$id"] for schema in self.json_schemas]
+            self.metadata_schema_urls = [schema.get("$id") or schema.get("id") for schema in self.json_schemas]
 
         self.template_version = "1.0.0"
         self.created_date = str(datetime.now())

--- a/ingest/template/schema_template.py
+++ b/ingest/template/schema_template.py
@@ -17,6 +17,7 @@ class SchemaTemplate():
     """ A SchemaTemplate is used to encapsulate information about all the metadata schema files and
     property migration files that are directly passed in in order to generate a spreadsheet. """
 
+    # TODO: simplify construction, move existing opinionated constructor to a static method or builder
     def __init__(self, ingest_api_url="http://api.ingest.dev.data.humancellatlas.org",
                  migrations_url="https://schema.dev.data.humancellatlas.org/property_migrations",
                  metadata_schema_urls=None, json_schema_docs=None, tab_config=None, property_migrations=None,
@@ -86,6 +87,8 @@ class SchemaTemplate():
         self.json_schemas = json_schema_docs
         if not self.json_schemas:
             self.json_schemas = self._get_json_objs_from_metadata_schema_urls()
+        else:
+            self.metadata_schema_urls = [schema["$id"] for schema in self.json_schemas]
 
         self.template_version = "1.0.0"
         self.created_date = str(datetime.now())

--- a/ingest/template/vanilla_spreadsheet_builder.py
+++ b/ingest/template/vanilla_spreadsheet_builder.py
@@ -16,7 +16,7 @@ class VanillaSpreadsheetBuilder(SpreadsheetBuilder):
         super(VanillaSpreadsheetBuilder, self).create_initial_spreadsheet(output_file, hide_row)
 
     def build(self, spreadsheet_tabs_template: SchemaTemplate):
-        tabs = spreadsheet_tabs_template.tabs
+        tabs = spreadsheet_tabs_template.spreadsheet_configuration.lookup("tabs")
 
         for tab in tabs:
             for tab_name, detail in tab.items():

--- a/ingest/template/vanilla_spreadsheet_builder.py
+++ b/ingest/template/vanilla_spreadsheet_builder.py
@@ -4,6 +4,7 @@ Given a tabs template and list of schema URLs, will output a spreadsheet in Exce
 """
 
 from .spreadsheet_builder import SpreadsheetBuilder
+from .schema_template import SchemaTemplate
 
 # TODO(maniarathi): Consolidate default values into a shared configuration file.
 DEFAULT_INGEST_URL = "http://api.ingest.data.humancellatlas.org"
@@ -14,7 +15,7 @@ class VanillaSpreadsheetBuilder(SpreadsheetBuilder):
     def __init__(self, output_file, hide_row=False):
         super(VanillaSpreadsheetBuilder, self).create_initial_spreadsheet(output_file, hide_row)
 
-    def build(self, spreadsheet_tabs_template):
+    def build(self, spreadsheet_tabs_template: SchemaTemplate):
         tabs = spreadsheet_tabs_template.tabs
 
         for tab in tabs:
@@ -75,4 +76,4 @@ class VanillaSpreadsheetBuilder(SpreadsheetBuilder):
                         worksheet.write(4, column_index, '', self.header_format)
 
         if self.include_schemas_tab:
-            self.generate_and_add_schema_worksheet_to_spreadsheet(spreadsheet_tabs_template.get_schema_urls())
+            self.generate_and_add_schema_worksheet_to_spreadsheet(spreadsheet_tabs_template.metadata_schema_urls)


### PR DESCRIPTION
Fixed some bugs that seemingly arose after the SchemaTemplate and spreadsheet builder utils were refactored a while back. Required for the spreadsheet generator service in the ingest-broker, and also allows the "UI Template Generator" to work with the latest version of ingest-client