### PR TITLE
Submission entity POST endpoints will now always accept payload with content attribute

### DIFF
--- a/ingest/api/ingestapi.py
+++ b/ingest/api/ingestapi.py
@@ -307,7 +307,7 @@ class IngestApi:
     def create_file(self, submission_url, filename, content, uuid=None):
         submission_files_url = self.get_link_in_submission(submission_url, 'files')
 
-        submission_files_url = submission_files_url + "/" + quote(filename)
+        submission_files_url = submission_files_url
 
         file_to_create_object = {
             "fileName": filename,
@@ -362,7 +362,7 @@ class IngestApi:
         submission_url = self.get_link_in_submission(submission_url, entity_type)
         self.logger.debug(f"POST {submission_url} {json.dumps(content)}")
 
-        r = self.session.post(submission_url, json=content, headers=self.get_headers(), params=params)
+        r = self.session.post(submission_url, json={'content': content}, headers=self.get_headers(), params=params)
         r.raise_for_status()
         return r.json()
 

--- a/ingest/api/ingestapi.py
+++ b/ingest/api/ingestapi.py
@@ -293,21 +293,19 @@ class IngestApi:
             return len(result["_embedded"][entity_type])
 
     def create_project(self, submission_url, content, uuid=None):
-        return self.create_entity(submission_url, content, "projects", uuid)
+        return self.create_entity(submission_url, {'content': content}, "projects", uuid)
 
     def create_biomaterial(self, submission_url, content, uuid=None):
-        return self.create_entity(submission_url, content, "biomaterials", uuid)
+        return self.create_entity(submission_url, {'content': content}, "biomaterials", uuid)
 
-    def create_process(self, submission_url, json_object, uuid=None):
-        return self.create_entity(submission_url, json_object, "processes", uuid)
+    def create_process(self, submission_url, content, uuid=None):
+        return self.create_entity(submission_url, {'content': content}, "processes", uuid)
 
     def create_protocol(self, submission_url, content, uuid=None):
-        return self.create_entity(submission_url, content, "protocols", uuid)
+        return self.create_entity(submission_url, {'content': content}, "protocols", uuid)
 
     def create_file(self, submission_url, filename, content, uuid=None):
         submission_files_url = self.get_link_in_submission(submission_url, 'files')
-
-        submission_files_url = submission_files_url
 
         file_to_create_object = {
             "fileName": filename,
@@ -354,15 +352,15 @@ class IngestApi:
     def create_submission_error(self, submission_url, data):
         return self.create_entity(submission_url, data, 'submissionEnvelopeErrors')
 
-    def create_entity(self, submission_url, content, entity_type, uuid=None):
+    def create_entity(self, submission_url, data, entity_type, uuid=None):
         params = {}
         if uuid:
             params["updatingUuid"] = uuid
 
         submission_url = self.get_link_in_submission(submission_url, entity_type)
-        self.logger.debug(f"POST {submission_url} {json.dumps(content)}")
+        self.logger.debug(f"POST {submission_url} {json.dumps(data)}")
 
-        r = self.session.post(submission_url, json={'content': content}, headers=self.get_headers(), params=params)
+        r = self.session.post(submission_url, json=data, headers=self.get_headers(), params=params)
         r.raise_for_status()
         return r.json()
 

--- a/ingest/importer/submission.py
+++ b/ingest/importer/submission.py
@@ -49,7 +49,8 @@ class IngestSubmitter(object):
             for link in entity.direct_links:
                 to_entity = entity_map.get_entity(link['entity'], link['id'])
                 try:
-                    submission.link_entity(entity, to_entity, relationship=link['relationship'], is_collection=link.get('is_collection', True))
+                    submission.link_entity(entity, to_entity, relationship=link['relationship'],
+                                           is_collection=link.get('is_collection', True))
                     progress = progress + 1
                     expected_links = int(submission.manifest.get('expectedLinks', 0))
                     if progress % self.PROGRESS_CTR == 0 or (progress == expected_links):
@@ -353,7 +354,7 @@ class Submission(object):
                                                       uuid=uuid)
         else:
             response = self.ingest_api.create_entity(self.submission_url,
-                                                     entity.content,
+                                                     {"content": entity.content},
                                                      link_name, uuid=uuid)
         entity.ingest_json = response
         self.metadata_dict[entity.type + '.' + entity.id] = entity

--- a/tests/unit/api/test_ingestapi.py
+++ b/tests/unit/api/test_ingestapi.py
@@ -31,7 +31,7 @@ class IngestApiTest(TestCase):
 
         file = ingest_api.create_file(submission_url, filename, {})
         self.assertEqual(file, {'uuid': 'file-uuid'})
-        mock_requests_post.assert_called_with('url/sub/id/files/mock-filename',
+        mock_requests_post.assert_called_with('url/sub/id/files',
                                               headers={'Content-type': 'application/json',
                                                        'Authorization': 'Bearer token'},
                                               json={'fileName': 'mock-filename', 'content': {}},


### PR DESCRIPTION
Adjustments to changes in PR: https://github.com/ebi-ait/ingest-core/pull/54
user story task ticket: ebi-ait/dcp-ingest-central#109