### PR TITLE
 Allow setting of custom audience when generating JWT

### DIFF
--- a/ingest/utils/s2s_token_client.py
+++ b/ingest/utils/s2s_token_client.py
@@ -5,17 +5,29 @@ from .dcp_auth_client import DCPAuthClient
 
 
 class S2STokenClient:
-    def __init__(self, dcp_auth_client: 'DCPAuthClient' = None):
-        self.dcp_auth_client = dcp_auth_client
+    def __init__(self, credentials: dict, audience: str = None):
+        self._credentials = credentials
+        self.audience = audience
 
-    def setup_from_env_var(self, env_var_name):
-        key_dict = json.loads(os.environ.get(env_var_name))
-        self.dcp_auth_client = DCPAuthClient(key_dict["project_id"], key_dict)
+    @classmethod
+    def from_env_var(cls, env_var_name):
+        service_credentials = json.loads(os.environ.get(env_var_name))
+        return cls(service_credentials)
 
-    def setup_from_file(self, file_path):
+    @classmethod
+    def from_file(cls, file_path):
         with open(file_path) as fh:
             service_credentials = json.load(fh)
-        self.dcp_auth_client = DCPAuthClient(service_credentials["project_id"], service_credentials)
+        return cls(service_credentials)
+
+    def set_audience(self, audience: str):
+        self.audience = audience
 
     def retrieve_token(self) -> str:
-        return self.dcp_auth_client.token
+        if not self.audience:
+            raise Error('The audience must be set.')
+        return DCPAuthClient.get_service_jwt(service_credentials=self._credentials, audience=self.audience)
+
+
+class Error(Exception):
+    """Base-class for all exceptions raised by this module."""

--- a/ingest/utils/s2s_token_client.py
+++ b/ingest/utils/s2s_token_client.py
@@ -4,10 +4,9 @@ import os
 from .dcp_auth_client import DCPAuthClient
 
 
-class S2STokenClient:
-    def __init__(self, credentials: dict, audience: str = None):
-        self._credentials = credentials
-        self.audience = audience
+class ServiceCredential:
+    def __init__(self, value: dict):
+        self.value = value
 
     @classmethod
     def from_env_var(cls, env_var_name):
@@ -20,13 +19,16 @@ class S2STokenClient:
             service_credentials = json.load(fh)
         return cls(service_credentials)
 
-    def set_audience(self, audience: str):
-        self.audience = audience
+
+class S2STokenClient:
+    def __init__(self, credential: ServiceCredential, audience: str):
+        self._credentials = credential
+        self._audience = audience
 
     def retrieve_token(self) -> str:
-        if not self.audience:
+        if not self._audience:
             raise Error('The audience must be set.')
-        return DCPAuthClient.get_service_jwt(service_credentials=self._credentials, audience=self.audience)
+        return DCPAuthClient.get_service_jwt(service_credentials=self._credentials.value, audience=self._audience)
 
 
 class Error(Exception):

--- a/ingest/utils/s2s_token_client.py
+++ b/ingest/utils/s2s_token_client.py
@@ -1,11 +1,12 @@
 import json
 import os
+from typing import Dict
 
 from .dcp_auth_client import DCPAuthClient
 
 
 class ServiceCredential:
-    def __init__(self, value: dict):
+    def __init__(self, value: Dict[str, str]):
         self.value = value
 
     @classmethod

--- a/tests/integration/test_spreadsheet_import.py
+++ b/tests/integration/test_spreadsheet_import.py
@@ -16,7 +16,7 @@ DEPLOYMENT = 'develop'
 SPREADSHEET_FILE = 'dcp_integration_test_metadata_1_SS2_bundle.xlsx'
 SPREADSHEET_LOCATION = f'https://raw.github.com/HumanCellAtlas/metadata-schema/{DEPLOYMENT}/infrastructure_testing_files' \
                        f'/current/{SPREADSHEET_FILE}'
-
+TOKEN_AUDIENCE = 'https://dev.data.humancellatlas.org/'
 
 def download_file(url, path):
     response = requests.get(url)
@@ -33,10 +33,9 @@ class SpreadsheetImport(TestCase):
         self.configure_ingest_client()
 
     def configure_ingest_client(self):
-        self.s2s_token_client = S2STokenClient()
         gcp_credentials_file = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
-
-        self.s2s_token_client.setup_from_file(gcp_credentials_file)
+        self.s2s_token_client = S2STokenClient.from_file(gcp_credentials_file)
+        self.s2s_token_client.set_audience(TOKEN_AUDIENCE)
         self.token_manager = TokenManager(self.s2s_token_client)
         self.ingest_api = IngestApi(url=INGEST_API, token_manager=self.token_manager)
 

--- a/tests/integration/test_spreadsheet_import.py
+++ b/tests/integration/test_spreadsheet_import.py
@@ -5,18 +5,18 @@ import requests
 from unittest import TestCase
 from tests.utils import delete_file
 
-
 from ingest.api.ingestapi import IngestApi
 from ingest.importer.importer import XlsImporter
-from ingest.utils.s2s_token_client import S2STokenClient
+from ingest.utils.s2s_token_client import S2STokenClient, ServiceCredential
 from ingest.utils.token_manager import TokenManager
 
-INGEST_API = 'https://api.ingest.dev.archive.data.humancellatlas.org/'
+INGEST_API = os.environ.get('INGEST_API', 'https://api.ingest.dev.archive.data.humancellatlas.org/')
 DEPLOYMENT = 'develop'
 SPREADSHEET_FILE = 'dcp_integration_test_metadata_1_SS2_bundle.xlsx'
 SPREADSHEET_LOCATION = f'https://raw.github.com/HumanCellAtlas/metadata-schema/{DEPLOYMENT}/infrastructure_testing_files' \
                        f'/current/{SPREADSHEET_FILE}'
-INGEST_API_JWT_AUDIENCE = 'https://dev.data.humancellatlas.org/'
+INGEST_API_JWT_AUDIENCE = os.environ.get('INGEST_API_JWT_AUDIENCE', 'https://dev.data.humancellatlas.org/')
+
 
 def download_file(url, path):
     response = requests.get(url)
@@ -26,7 +26,7 @@ def download_file(url, path):
 
 
 @unittest.skipIf(not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS'),
-    'The environment variable GOOGLE_APPLICATION_CREDENTIALS should contain the location of GCP credentials file')
+                 'The environment variable GOOGLE_APPLICATION_CREDENTIALS should contain the location of GCP credentials file')
 class SpreadsheetImport(TestCase):
     def setUp(self):
         self.test_data_path = os.path.dirname(os.path.realpath(__file__))
@@ -34,8 +34,8 @@ class SpreadsheetImport(TestCase):
 
     def configure_ingest_client(self):
         gcp_credentials_file = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
-        self.s2s_token_client = S2STokenClient.from_file(gcp_credentials_file)
-        self.s2s_token_client.set_audience(INGEST_API_JWT_AUDIENCE)
+        self.s2s_token_client = S2STokenClient(ServiceCredential.from_file(gcp_credentials_file),
+                                               INGEST_API_JWT_AUDIENCE)
         self.token_manager = TokenManager(self.s2s_token_client)
         self.ingest_api = IngestApi(url=INGEST_API, token_manager=self.token_manager)
 

--- a/tests/integration/test_spreadsheet_import.py
+++ b/tests/integration/test_spreadsheet_import.py
@@ -16,7 +16,7 @@ DEPLOYMENT = 'develop'
 SPREADSHEET_FILE = 'dcp_integration_test_metadata_1_SS2_bundle.xlsx'
 SPREADSHEET_LOCATION = f'https://raw.github.com/HumanCellAtlas/metadata-schema/{DEPLOYMENT}/infrastructure_testing_files' \
                        f'/current/{SPREADSHEET_FILE}'
-TOKEN_AUDIENCE = 'https://dev.data.humancellatlas.org/'
+INGEST_API_JWT_AUDIENCE = 'https://dev.data.humancellatlas.org/'
 
 def download_file(url, path):
     response = requests.get(url)
@@ -35,7 +35,7 @@ class SpreadsheetImport(TestCase):
     def configure_ingest_client(self):
         gcp_credentials_file = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
         self.s2s_token_client = S2STokenClient.from_file(gcp_credentials_file)
-        self.s2s_token_client.set_audience(TOKEN_AUDIENCE)
+        self.s2s_token_client.set_audience(INGEST_API_JWT_AUDIENCE)
         self.token_manager = TokenManager(self.s2s_token_client)
         self.ingest_api = IngestApi(url=INGEST_API, token_manager=self.token_manager)
 

--- a/tests/unit/utils/test_s2s_token_client.py
+++ b/tests/unit/utils/test_s2s_token_client.py
@@ -1,22 +1,22 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
-from ingest.utils.s2s_token_client import S2STokenClient, Error as S2STokenClientError
+from ingest.utils.s2s_token_client import S2STokenClient, Error as S2STokenClientError, ServiceCredential
 
 
 class TestS2STokenClient(TestCase):
 
     @patch('ingest.utils.dcp_auth_client.DCPAuthClient.get_service_jwt')
-    def test__retrieve_token__returns_token__with_creds_audience_set(self, mock_retrieve_token):
+    def test__retrieve_token__returns_token__with_creds_and_audience(self, mock_retrieve_token):
         mock_retrieve_token.return_value = 'token'
-        token_client = S2STokenClient(credentials={}, audience='audience')
+        token_client = S2STokenClient(credential=ServiceCredential({}), audience='audience')
 
         token = token_client.retrieve_token()
 
         self.assertEqual(token, 'token')
 
-    def test__retrieve_token__raises_error__when_no_audience_set(self):
-        token_client = S2STokenClient(credentials={}, audience=None)
+    def test__retrieve_token__raises_error__with_no_audience(self):
+        token_client = S2STokenClient(credential=ServiceCredential({}), audience=None)
 
         with self.assertRaises(S2STokenClientError):
             token = token_client.retrieve_token()

--- a/tests/unit/utils/test_s2s_token_client.py
+++ b/tests/unit/utils/test_s2s_token_client.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from ingest.utils.s2s_token_client import S2STokenClient, Error as S2STokenClientError
+
+
+class TestS2STokenClient(TestCase):
+
+    @patch('ingest.utils.dcp_auth_client.DCPAuthClient.get_service_jwt')
+    def test__retrieve_token__returns_token__with_creds_audience_set(self, mock_retrieve_token):
+        mock_retrieve_token.return_value = 'token'
+        token_client = S2STokenClient(credentials={}, audience='audience')
+
+        token = token_client.retrieve_token()
+
+        self.assertEqual(token, 'token')
+
+    def test__retrieve_token__raises_error__when_no_audience_set(self):
+        token_client = S2STokenClient(credentials={}, audience=None)
+
+        with self.assertRaises(S2STokenClientError):
+            token = token_client.retrieve_token()
+            self.assertEqual(token, None)


### PR DESCRIPTION
ebi-ait/hca-ebi-dev-team#370

It seems that there is a strict logic in the DCPAuthClient class that sets the audience based on the Google cloud project name. This change should provide a more flexible way of setting the audience when generating JWT's. 

The components which are using the S2STokenClient class will soon be adjusted.