### PR TITLE
Only create module worksheet for project non ontology modules

### DIFF
--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -81,11 +81,13 @@ class Flattener:
 
     def _flatten_object_list(self, flattened_object: dict, object: dict, parent_key: str):
         if self._is_list_of_ontology_objects(object):
-            self._flatten_ontology_list(object, flattened_object, parent_key)
-        else:
+            self._flatten_include_object_list_to_main_entity(object, flattened_object, parent_key)
+        elif self._is_project(parent_key):
             self.flatten(object, parent_key)
+        else:
+            self._flatten_include_object_list_to_main_entity(object, flattened_object, parent_key)
 
-    def _flatten_ontology_list(self, object: dict, flattened_object: dict, parent_key: str):
+    def _flatten_include_object_list_to_main_entity(self, object: dict, flattened_object: dict, parent_key: str):
         keys = self._get_keys_of_a_list_of_object(object)
         for key in keys:
             flattened_object[f'{parent_key}.{key}'] = SCALAR_LIST_DELIMETER.join([elem[key] for elem in object])
@@ -110,3 +112,7 @@ class Flattener:
 
     def _get_concrete_entity(self, content: dict):
         return content.get('describedBy').rsplit('/', 1)[-1]
+
+    def _is_project(self, parent_key: str):
+        entity_type = parent_key.split('.')[0]
+        return entity_type == 'project'

--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -81,13 +81,13 @@ class Flattener:
 
     def _flatten_object_list(self, flattened_object: dict, object: dict, parent_key: str):
         if self._is_list_of_ontology_objects(object):
-            self._flatten_include_object_list_to_main_entity(object, flattened_object, parent_key)
+            self._flatten_to_include_object_list_to_main_entity_worksheet(object, flattened_object, parent_key)
         elif self._is_project(parent_key):
             self.flatten(object, parent_key)
         else:
-            self._flatten_include_object_list_to_main_entity(object, flattened_object, parent_key)
+            self._flatten_to_include_object_list_to_main_entity_worksheet(object, flattened_object, parent_key)
 
-    def _flatten_include_object_list_to_main_entity(self, object: dict, flattened_object: dict, parent_key: str):
+    def _flatten_to_include_object_list_to_main_entity_worksheet(self, object: dict, flattened_object: dict, parent_key: str):
         keys = self._get_keys_of_a_list_of_object(object)
         for key in keys:
             flattened_object[f'{parent_key}.{key}'] = SCALAR_LIST_DELIMETER.join([elem[key] for elem in object])

--- a/tests/unit/downloader/collection_protocol-list-flattened.json
+++ b/tests/unit/downloader/collection_protocol-list-flattened.json
@@ -1,0 +1,42 @@
+{
+  "Collection protocol": {
+    "headers": [
+      "collection_protocol.uuid",
+      "collection_protocol.protocol_core.protocol_id",
+      "collection_protocol.protocol_core.protocol_name",
+      "collection_protocol.protocol_core.protocol_description",
+      "collection_protocol.protocol_core.publication_doi",
+      "collection_protocol.protocol_core.protocols_io_doi",
+      "collection_protocol.protocol_core.document",
+      "collection_protocol.method.text",
+      "collection_protocol.method.ontology",
+      "collection_protocol.method.ontology_label",
+      "collection_protocol.reagents.retail_name",
+      "collection_protocol.reagents.catalog_number",
+      "collection_protocol.reagents.manufacturer",
+      "collection_protocol.reagents.lot_number",
+      "collection_protocol.reagents.expiry_date",
+      "collection_protocol.reagents.kit_titer"
+    ],
+    "values": [
+      {
+        "collection_protocol.uuid": "6fda6635-940b-433d-9601-2388e847c000",
+        "collection_protocol.protocol_core.protocol_id": "collection_protocol_1",
+        "collection_protocol.protocol_core.protocol_name": "A dummy collection protocol",
+        "collection_protocol.protocol_core.protocol_description": "A dummy collection protocol description",
+        "collection_protocol.protocol_core.publication_doi": "10.1101/193219",
+        "collection_protocol.protocol_core.protocols_io_doi": "10.17504/protocols.io.mgjc3un",
+        "collection_protocol.protocol_core.document": "my_cool_protocol.pdf",
+        "collection_protocol.method.text": "organ extraction",
+        "collection_protocol.method.ontology": "EFO:0009124",
+        "collection_protocol.method.ontology_label": "organ extraction",
+        "collection_protocol.reagents.retail_name": "SureCell WTA 3' Library Prep Kit",
+        "collection_protocol.reagents.catalog_number": "20014279",
+        "collection_protocol.reagents.manufacturer": "Illumina",
+        "collection_protocol.reagents.lot_number": "10001A",
+        "collection_protocol.reagents.expiry_date": "2018-01-31",
+        "collection_protocol.reagents.kit_titer": "Titer: Specification is 3.0x10^7"
+      }
+    ]
+  }
+}

--- a/tests/unit/downloader/collection_protocol-list.json
+++ b/tests/unit/downloader/collection_protocol-list.json
@@ -1,0 +1,68 @@
+[
+  {
+    "content": {
+      "describedBy": "https://schema.humancellatlas.org/type/protocol/biomaterial_collection/9.2.0/collection_protocol",
+      "schema_type": "protocol",
+      "protocol_core": {
+        "protocol_id": "collection_protocol_1",
+        "protocol_name": "A dummy collection protocol",
+        "protocol_description": "A dummy collection protocol description",
+        "publication_doi": "10.1101/193219",
+        "protocols_io_doi": "10.17504/protocols.io.mgjc3un",
+        "document": "my_cool_protocol.pdf"
+      },
+      "method": {
+        "text": "organ extraction",
+        "ontology": "EFO:0009124",
+        "ontology_label": "organ extraction"
+      },
+      "reagents": [
+        {
+          "retail_name": "SureCell WTA 3' Library Prep Kit",
+          "catalog_number": "20014279",
+          "manufacturer": "Illumina",
+          "lot_number": "10001A",
+          "expiry_date": "2018-01-31",
+          "kit_titer": "Titer: Specification is 3.0x10^7"
+        }
+      ]
+    },
+    "submissionDate": "2021-07-23T17:10:31.648Z",
+    "updateDate": "2021-07-23T17:10:33.413Z",
+    "user": null,
+    "lastModifiedUser": null,
+    "type": "Protocol",
+    "uuid": {
+      "uuid": "6fda6635-940b-433d-9601-2388e847c000"
+    },
+    "events": [],
+    "firstDcpVersion": "2021-07-23T17:10:31.648Z",
+    "dcpVersion": "2021-07-23T17:10:31.648Z",
+    "contentLastModified": "2021-07-23T17:10:31.631Z",
+    "accession": null,
+    "validationState": "Draft",
+    "validationErrors": null,
+    "isUpdate": false,
+    "linked": false,
+    "_links": {
+      "self": {
+        "href": "http://localhost:8080/protocols/60faf8079be1eb0df8b93a7a"
+      },
+      "protocol": {
+        "href": "http://localhost:8080/protocols/60faf8079be1eb0df8b93a7a",
+        "title": "A single protocol"
+      },
+      "validating": {
+        "href": "http://localhost:8080/protocols/60faf8079be1eb0df8b93a7a/validatingEvent"
+      },
+      "project": {
+        "href": "http://localhost:8080/protocols/60faf8079be1eb0df8b93a7a/project",
+        "title": "A single project"
+      },
+      "submissionEnvelope": {
+        "href": "http://localhost:8080/protocols/60faf8079be1eb0df8b93a7a/submissionEnvelope",
+        "title": "A single submission envelope"
+      }
+    }
+  }
+]

--- a/tests/unit/downloader/test_flattener.py
+++ b/tests/unit/downloader/test_flattener.py
@@ -83,7 +83,7 @@ class FlattenerTest(TestCase):
 
         self.assertEqual(actual, self.flattened_metadata_entity)
 
-    def test_flatten__has_modules(self):
+    def test_flatten__has_project_modules(self):
         # given
         self.content.update({"contributors": [
             {
@@ -174,6 +174,55 @@ class FlattenerTest(TestCase):
                 'project.organ_parts.ontology',
                 'project.organ_parts.ontology_label',
                 'project.organ_parts.text'
+            ]
+        )
+
+        # then
+        self.assertEqual(actual, self.flattened_metadata_entity)
+
+    def test_flatten__has_property_with_elements(self):
+        # given
+        content = {
+            "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/collection_protocol",
+            "schema_type": "protocol",
+            "organ_parts": [
+                {
+                    "field_1": "UBERON:0000376",
+                    "field_2": "hindlimb stylopod",
+                    "field_3": "hindlimb stylopod"
+                }
+            ]
+        }
+
+        self.metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [self.metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+        flattened_metadata_entity = {
+            'Collection Protocol' : {
+                'values': [{
+
+                }],
+                'headers':[]
+            }
+        }
+        flattened_metadata_entity['Collection Protocol']['values'][0].update({
+            'collection_protocol.organ_parts.field_1': 'UBERON:0000376',
+            'collection_protocol.organ_parts.field_2': 'hindlimb stylopod',
+            'collection_protocol.organ_parts.field_3': 'hindlimb stylopod',
+
+        })
+        flattened_metadata_entity['Collection Protocol']['headers'].extend(
+            [
+                'collection_protocol.organ_parts.field_1',
+                'collection_protocol.organ_parts.field_2',
+                'collection_protocol.organ_parts.field_3'
             ]
         )
 
@@ -488,6 +537,24 @@ class FlattenerTest(TestCase):
                 ]
             }
         }
+
+        # then
+        self.assertEqual(actual, expected)
+
+
+    def test_flatten__collection_protocol_metadata(self):
+        self.maxDiff = None
+
+        # given
+        with open('collection_protocol-list.json') as file:
+            entity_list = json.load(file)
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        with open('collection_protocol-list-flattened.json') as file:
+            expected = json.load(file)
 
         # then
         self.assertEqual(actual, expected)


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#13

Issue: User couldn't import spreadsheets with module worksheets like _Collection protocol - Reagents_ see 10x test spreadsheet

Karoly's steps to replicate the bug: https://github.com/ebi-ait/dcp-ingest-central/issues/13#issuecomment-885771674

Fix: The flattener shouldn't add this as a separate module worksheet.