### PR TITLE
Capture schema urls used in the entity list being flattened

### DIFF
--- a/ingest/downloader/downloader.py
+++ b/ingest/downloader/downloader.py
@@ -4,10 +4,10 @@ from openpyxl import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
 from ingest.downloader.flattener import Flattener
+from ingest.importer.spreadsheet.ingest_workbook import SCHEMAS_WORKSHEET
 from ingest.importer.spreadsheet.ingest_worksheet import START_DATA_ROW
 
 HEADER_ROW_NO = 4
-SCHEMAS_WORKSHEET = 'Schemas'
 
 
 class XlsDownloader:

--- a/ingest/downloader/downloader.py
+++ b/ingest/downloader/downloader.py
@@ -41,9 +41,7 @@ class XlsDownloader:
             raise Exception('The schema urls are missing')
         schemas_worksheet = workbook.create_sheet(SCHEMAS_WORKSHEET)
         schemas_worksheet.cell(row=1, column=1, value=SCHEMAS_WORKSHEET)
-        row_num = 1
-        for schema in schemas:
-            row_num += 1
+        for row_num, schema in enumerate(schemas, start=1):
             schemas_worksheet.cell(row=row_num, column=1, value=schema)
 
     def add_worksheet_content(self, worksheet, ws_elements: dict):

--- a/ingest/downloader/downloader.py
+++ b/ingest/downloader/downloader.py
@@ -41,7 +41,7 @@ class XlsDownloader:
             raise Exception('The schema urls are missing')
         schemas_worksheet = workbook.create_sheet(SCHEMAS_WORKSHEET)
         schemas_worksheet.cell(row=1, column=1, value=SCHEMAS_WORKSHEET)
-        for row_num, schema in enumerate(schemas, start=1):
+        for row_num, schema in enumerate(schemas, start=2):
             schemas_worksheet.cell(row=row_num, column=1, value=schema)
 
     def add_worksheet_content(self, worksheet, ws_elements: dict):

--- a/ingest/downloader/downloader.py
+++ b/ingest/downloader/downloader.py
@@ -38,7 +38,7 @@ class XlsDownloader:
     def generate_schemas_worksheet(self, input_json, workbook):
         schemas = input_json.get(SCHEMAS_WORKSHEET)
         if not schemas:
-            raise Exception('The schema urls are missing')
+            raise ValueError('The schema urls are missing')
         schemas_worksheet = workbook.create_sheet(SCHEMAS_WORKSHEET)
         schemas_worksheet.cell(row=1, column=1, value=SCHEMAS_WORKSHEET)
         for row_num, schema in enumerate(schemas, start=2):

--- a/ingest/downloader/downloader.py
+++ b/ingest/downloader/downloader.py
@@ -7,6 +7,7 @@ from ingest.downloader.flattener import Flattener
 from ingest.importer.spreadsheet.ingest_worksheet import START_DATA_ROW
 
 HEADER_ROW_NO = 4
+SCHEMAS_WORKSHEET = 'Schemas'
 
 
 class XlsDownloader:
@@ -23,12 +24,27 @@ class XlsDownloader:
         for ws_title, ws_elements in input_json.items():
             if ws_title == 'Project':
                 worksheet: Worksheet = workbook.create_sheet(title=ws_title, index=0)
+            elif ws_title == SCHEMAS_WORKSHEET:
+                continue
             else:
                 worksheet: Worksheet = workbook.create_sheet(title=ws_title)
 
             self.add_worksheet_content(worksheet, ws_elements)
 
+        self.generate_schemas_worksheet(input_json, workbook)
+
         return workbook
+
+    def generate_schemas_worksheet(self, input_json, workbook):
+        schemas = input_json.get(SCHEMAS_WORKSHEET)
+        if not schemas:
+            raise Exception('The schema urls are missing')
+        schemas_worksheet = workbook.create_sheet(SCHEMAS_WORKSHEET)
+        schemas_worksheet.cell(row=1, column=1, value=SCHEMAS_WORKSHEET)
+        row_num = 1
+        for schema in schemas:
+            row_num += 1
+            schemas_worksheet.cell(row=row_num, column=1, value=schema)
 
     def add_worksheet_content(self, worksheet, ws_elements: dict):
         headers = ws_elements.get('headers')

--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -110,7 +110,7 @@ class Flattener:
         for key in keys:
             flattened_object[f'{parent_key}.{key}'] = SCALAR_LIST_DELIMETER.join(
                 [elem.get(key) for elem in object
-                 if elem.get(key) is not None and elem.get(key) is not ''])
+                 if elem.get(key) is not None and elem.get(key) != ''])
 
     def _format_worksheet_name(self, worksheet_name):
         names = worksheet_name.split('.')

--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -50,13 +50,16 @@ class Flattener:
         concrete_entity = self._get_concrete_entity(content)
         schema_url = content.get('describedBy')
         existing_schema_url = self.schemas.get(concrete_entity)
+        self._validate_no_schema_version_conflicts(existing_schema_url, schema_url)
+
+        if not existing_schema_url:
+            self.schemas[concrete_entity] = schema_url
+
+    def _validate_no_schema_version_conflicts(self, existing_schema_url, schema_url):
         if existing_schema_url and existing_schema_url != schema_url:
             raise ValueError(f'The concrete entity schema version should be consistent across entities.\
                     Multiple versions of same concrete entity schema is found:\
                      {schema_url} and {existing_schema_url}')
-
-        if not existing_schema_url:
-            self.schemas[concrete_entity] = schema_url
 
     def _append_row_to_worksheet(self, row, worksheet):
         rows = worksheet.get('values')

--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from ingest.importer.spreadsheet.ingest_workbook import SCHEMAS_WORKSHEET
+
 MODULE_WORKSHEET_NAME_CONNECTOR = ' - '
 SCALAR_LIST_DELIMETER = '||'
 
@@ -15,7 +17,7 @@ class Flattener:
     def flatten(self, entity_list: List[dict], object_key: str = ''):
         for entity in entity_list:
             self._flatten_entity(entity, object_key)
-        self.workbook['Schemas'] = list(self.schemas.values())
+        self.workbook[SCHEMAS_WORKSHEET] = list(self.schemas.values())
         return self.workbook
 
     def _flatten_entity(self, entity, object_key):

--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -27,8 +27,7 @@ class Flattener:
 
         if not object_key:
             content = entity['content']
-            concrete_entity = self._get_concrete_entity(content)
-            worksheet_name = concrete_entity
+            worksheet_name = self._get_concrete_entity(content)
             row = {f'{worksheet_name}.uuid': entity['uuid']['uuid']}
             self._extract_schema_url(content)
 

--- a/ingest/downloader/flattener.py
+++ b/ingest/downloader/flattener.py
@@ -31,7 +31,7 @@ class Flattener:
             self._extract_schema_url(content)
 
         if not worksheet_name:
-            raise Error('There should be a worksheet name')
+            raise ValueError('There should be a worksheet name')
 
         self._flatten_object(content, row, parent_key=worksheet_name)
 
@@ -51,7 +51,7 @@ class Flattener:
         schema_url = content.get('describedBy')
         existing_schema_url = self.schemas.get(concrete_entity)
         if existing_schema_url and existing_schema_url != schema_url:
-            raise Error(f'The concrete entity schema version should be consistent across entities.\
+            raise ValueError(f'The concrete entity schema version should be consistent across entities.\
                     Multiple versions of same concrete entity schema is found:\
                      {schema_url} and {existing_schema_url}')
 
@@ -137,7 +137,3 @@ class Flattener:
     def _is_project(self, parent_key: str):
         entity_type = parent_key.split('.')[0]
         return entity_type == 'project'
-
-
-class Error(Exception):
-    """Base-class for all exceptions raised by this module."""

--- a/tests/unit/downloader/collection_protocol-list-flattened.json
+++ b/tests/unit/downloader/collection_protocol-list-flattened.json
@@ -38,5 +38,8 @@
         "collection_protocol.reagents.kit_titer": "Titer: Specification is 3.0x10^7"
       }
     ]
-  }
+  },
+  "Schemas": [
+    "https://schema.humancellatlas.org/type/protocol/biomaterial_collection/9.2.0/collection_protocol"
+  ]
 }

--- a/tests/unit/downloader/content-flattened.json
+++ b/tests/unit/downloader/content-flattened.json
@@ -1,0 +1,21 @@
+{
+  "Project": {
+    "headers": [
+      "project.uuid",
+      "project.project_core.project_short_name",
+      "project.project_core.project_title",
+      "project.project_core.project_description"
+    ],
+    "values": [
+      {
+        "project.uuid": "uuid1",
+        "project.project_core.project_short_name": "label",
+        "project.project_core.project_title": "title",
+        "project.project_core.project_description": "desc"
+      }
+    ]
+  },
+  "Schemas": [
+    "https://schema.humancellatlas.org/type/project/14.2.0/project"
+  ]
+}

--- a/tests/unit/downloader/content.json
+++ b/tests/unit/downloader/content.json
@@ -1,0 +1,9 @@
+{
+  "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/project",
+  "schema_type": "project",
+  "project_core": {
+    "project_short_name": "label",
+    "project_title": "title",
+    "project_description": "desc"
+  }
+}

--- a/tests/unit/downloader/entities-flattened.json
+++ b/tests/unit/downloader/entities-flattened.json
@@ -1,0 +1,67 @@
+{
+  "Project": {
+    "headers": [
+      "project.uuid",
+      "project.project_core.project_short_name",
+      "project.project_core.project_title",
+      "project.project_core.project_description"
+    ],
+    "values": [
+      {
+        "project.uuid": "uuid1",
+        "project.project_core.project_short_name": "label",
+        "project.project_core.project_title": "title",
+        "project.project_core.project_description": "desc"
+      }
+    ]
+  },
+  "Project - Contributors": {
+    "headers": [
+      "project.contributors.name",
+      "project.contributors.email",
+      "project.contributors.institution",
+      "project.contributors.laboratory",
+      "project.contributors.country",
+      "project.contributors.corresponding_contributor",
+      "project.contributors.project_role.text",
+      "project.contributors.project_role.ontology",
+      "project.contributors.project_role.ontology_label"
+    ],
+    "values": [
+      {
+        "project.contributors.corresponding_contributor": "True",
+        "project.contributors.country": "USA",
+        "project.contributors.email": "alex.pollen@ucsf.edu",
+        "project.contributors.institution": "University of California, San Francisco (UCSF)",
+        "project.contributors.laboratory": "Department of Neurology",
+        "project.contributors.name": "Alex A,,Pollen",
+        "project.contributors.project_role.ontology": "EFO:0009741",
+        "project.contributors.project_role.ontology_label": "experimental scientist",
+        "project.contributors.project_role.text": "experimental scientist"
+      }
+    ]
+  },
+  "Donor organism": {
+    "headers": [
+      "donor_organism.uuid",
+      "donor_organism.biomaterial_core.biomaterial_id",
+      "donor_organism.biomaterial_core.biomaterial_description"
+    ],
+    "values": [
+      {
+        "donor_organism.uuid": "uuid2",
+        "donor_organism.biomaterial_core.biomaterial_id": "label",
+        "donor_organism.biomaterial_core.biomaterial_description": "desc"
+      },
+      {
+        "donor_organism.uuid": "uuid3",
+        "donor_organism.biomaterial_core.biomaterial_id": "label",
+        "donor_organism.biomaterial_core.biomaterial_description": "desc"
+      }
+    ]
+  },
+  "Schemas": [
+    "https://schema.humancellatlas.org/type/project/14.2.0/project",
+    "https://schema.humancellatlas.org/type/project/14.2.0/donor_organism"
+            ]
+        }

--- a/tests/unit/downloader/entities.json
+++ b/tests/unit/downloader/entities.json
@@ -1,0 +1,57 @@
+[
+  {
+    "content": {
+      "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/project",
+      "schema_type": "project",
+      "project_core": {
+        "project_short_name": "label",
+        "project_title": "title",
+        "project_description": "desc"
+      },
+      "contributors": [
+        {
+          "name": "Alex A,,Pollen",
+          "email": "alex.pollen@ucsf.edu",
+          "institution": "University of California, San Francisco (UCSF)",
+          "laboratory": "Department of Neurology",
+          "country": "USA",
+          "corresponding_contributor": true,
+          "project_role": {
+            "text": "experimental scientist",
+            "ontology": "EFO:0009741",
+            "ontology_label": "experimental scientist"
+          }
+        }
+      ]
+    },
+    "uuid": {
+      "uuid": "uuid1"
+    }
+  },
+  {
+    "content": {
+      "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/donor_organism",
+      "schema_type": "biomaterial",
+      "biomaterial_core": {
+        "biomaterial_id": "label",
+        "biomaterial_description": "desc"
+      }
+    },
+    "uuid": {
+      "uuid": "uuid2"
+    }
+  },
+  {
+    "content": {
+      "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/donor_organism",
+      "schema_type": "biomaterial",
+      "biomaterial_core": {
+        "biomaterial_id": "label",
+        "biomaterial_description": "desc"
+      }
+    },
+    "uuid": {
+      "uuid": "uuid3"
+    }
+  }
+]

--- a/tests/unit/downloader/project-list-flattened.json
+++ b/tests/unit/downloader/project-list-flattened.json
@@ -122,5 +122,8 @@
         "project.funders.organization": "NIH HHS"
       }
     ]
-  }
+  },
+  "Schemas": [
+    "https://schema.humancellatlas.org/type/project/14.2.0/project"
+  ]
 }

--- a/tests/unit/downloader/test_data_collector.py
+++ b/tests/unit/downloader/test_data_collector.py
@@ -1,7 +1,6 @@
 import json
 import os
 import unittest
-from os.path import dirname
 from unittest.mock import MagicMock
 
 from ingest.api.ingestapi import IngestApi
@@ -18,10 +17,36 @@ class DataCollectorTest(unittest.TestCase):
         self.parent_dir = os.path.split(self.script_dir)[0]
         self.resources_dir = os.path.join(self.parent_dir, 'resources')
 
-
     def test_collected_project_and_biomaterials_data_by_submission_uuid_returns_correctly(self):
-        #given
+        # given
+        project = self._make_project_data()
+        self._mock_ingest_api(project)
+
+        expected_json = [project['project']] + \
+                        project['biomaterials'] + \
+                        project['processes'] + \
+                        project['protocols'] + \
+                        project['files']
+
+        # when
         project_uuid = '1234'
+        result_json = self.data_collector.collect_data_by_submission_uuid(project_uuid)
+
+        # then
+        self.assertEqual(result_json, expected_json)
+
+    def _mock_ingest_api(self, project):
+        self.mock_ingest_api.get_submission_by_uuid.return_value = project['submission']
+        self.mock_ingest_api.get_related_project.return_value = project['project']
+        self.mock_ingest_api.get_related_entities.side_effect = \
+            [
+                iter(project['biomaterials']),
+                iter(project['processes']),
+                iter(project['protocols']),
+                iter(project['files'])
+            ]
+
+    def _make_project_data(self):
         with open(self.resources_dir + '/mock_submission.json') as file:
             mock_submission_json = json.load(file)
         with open(self.resources_dir + '/mock_project.json') as file:
@@ -35,31 +60,14 @@ class DataCollectorTest(unittest.TestCase):
         with open(self.resources_dir + '/mock_files.json') as file:
             mock_files_json = json.load(file)
 
-        self.mock_ingest_api.get_submission_by_uuid.return_value = mock_submission_json
-        self.mock_ingest_api.get_related_project.return_value = mock_project_json
-        self.mock_ingest_api.get_related_entities.side_effect = \
-            [
-                iter(mock_biomaterials_json),
-                iter(mock_processes_json),
-                iter(mock_protocols_json),
-                iter(mock_files_json)
-            ]
-
-        expected_json = [
-            mock_project_json,
-        ]
-        expected_json.extend(
-            mock_biomaterials_json
-            + mock_processes_json
-            + mock_protocols_json
-            + mock_files_json
-        )
-
-        #when
-        result_json = self.data_collector.collect_data_by_submission_uuid(project_uuid)
-
-        #then
-        self.assertEqual(result_json, expected_json)
+        return {
+            'submission': mock_submission_json,
+            'project': mock_project_json,
+            'biomaterials': mock_biomaterials_json,
+            'processes': mock_processes_json,
+            'protocols': mock_protocols_json,
+            'files': mock_files_json
+        }
 
 
 if __name__ == '__main__':

--- a/tests/unit/downloader/test_data_collector.py
+++ b/tests/unit/downloader/test_data_collector.py
@@ -1,5 +1,7 @@
 import json
+import os
 import unittest
+from os.path import dirname
 from unittest.mock import MagicMock
 
 from ingest.api.ingestapi import IngestApi
@@ -12,21 +14,25 @@ class DataCollectorTest(unittest.TestCase):
         self.maxDiff = None
         self.mock_ingest_api = MagicMock(spec=IngestApi)
         self.data_collector = DataCollector(self.mock_ingest_api)
+        self.script_dir = os.path.dirname(__file__)
+        self.parent_dir = os.path.split(self.script_dir)[0]
+        self.resources_dir = os.path.join(self.parent_dir, 'resources')
+
 
     def test_collected_project_and_biomaterials_data_by_submission_uuid_returns_correctly(self):
         #given
         project_uuid = '1234'
-        with open('../resources/mock_submission.json') as file:
+        with open(self.resources_dir + '/mock_submission.json') as file:
             mock_submission_json = json.load(file)
-        with open('../resources/mock_project.json') as file:
+        with open(self.resources_dir + '/mock_project.json') as file:
             mock_project_json = json.load(file)
-        with open('../resources/mock_biomaterials.json') as file:
+        with open(self.resources_dir + '/mock_biomaterials.json') as file:
             mock_biomaterials_json = json.load(file)
-        with open('../resources/mock_processes.json') as file:
+        with open(self.resources_dir + '/mock_processes.json') as file:
             mock_processes_json = json.load(file)
-        with open('../resources/mock_protocols.json') as file:
+        with open(self.resources_dir + '/mock_protocols.json') as file:
             mock_protocols_json = json.load(file)
-        with open('../resources/mock_files.json') as file:
+        with open(self.resources_dir + '/mock_files.json') as file:
             mock_files_json = json.load(file)
 
         self.mock_ingest_api.get_submission_by_uuid.return_value = mock_submission_json

--- a/tests/unit/downloader/test_flatten_concrete_entity.py
+++ b/tests/unit/downloader/test_flatten_concrete_entity.py
@@ -6,8 +6,6 @@ from tests.unit.downloader.test_flattener import FlattenerTest
 
 class FlattenConcreteEntityTest(FlattenerTest):
     def test_flatten__project_metadata(self):
-        self.maxDiff = None
-
         # given
         with open(self.script_dir + '/project-list.json') as file:
             entity_list = json.load(file)
@@ -21,7 +19,6 @@ class FlattenConcreteEntityTest(FlattenerTest):
 
         # then
         self.assertEqual(actual, expected)
-
 
     def test_flatten__has_different_entities(self):
         # given
@@ -37,7 +34,6 @@ class FlattenConcreteEntityTest(FlattenerTest):
 
         # then
         self.assertEqual(actual, expected)
-
 
     def test_flatten__collection_protocol_metadata(self):
         # given

--- a/tests/unit/downloader/test_flatten_concrete_entity.py
+++ b/tests/unit/downloader/test_flatten_concrete_entity.py
@@ -1,0 +1,55 @@
+import json
+
+from ingest.downloader.flattener import Flattener
+from tests.unit.downloader.test_flattener import FlattenerTest
+
+
+class FlattenConcreteEntityTest(FlattenerTest):
+    def test_flatten__project_metadata(self):
+        self.maxDiff = None
+
+        # given
+        with open(self.script_dir + '/project-list.json') as file:
+            entity_list = json.load(file)
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        with open(self.script_dir + '/project-list-flattened.json') as file:
+            expected = json.load(file)
+
+        # then
+        self.assertEqual(actual, expected)
+
+
+    def test_flatten__has_different_entities(self):
+        # given
+        with open(self.script_dir + '/entities.json') as file:
+            entity_list = json.load(file)
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        with open(self.script_dir + '/entities-flattened.json') as file:
+            expected = json.load(file)
+
+        # then
+        self.assertEqual(actual, expected)
+
+
+    def test_flatten__collection_protocol_metadata(self):
+        # given
+        with open(self.script_dir + '/collection_protocol-list.json') as file:
+            entity_list = json.load(file)
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        with open(self.script_dir + '/collection_protocol-list-flattened.json') as file:
+            expected = json.load(file)
+
+        # then
+        self.assertEqual(actual, expected)

--- a/tests/unit/downloader/test_flatten_ontology_module.py
+++ b/tests/unit/downloader/test_flatten_ontology_module.py
@@ -1,0 +1,204 @@
+from ingest.downloader.flattener import Flattener
+from tests.unit.downloader.test_flattener import FlattenerTest
+
+
+class FlattenOntologyModuleTest(FlattenerTest):
+    def test_flatten__has_ontology_property_with_multiple_elements(self):
+        # given
+        self.content.update({
+            'organ_parts': [
+                {
+                    'ontology': 'UBERON:0000376',
+                    'ontology_label': 'dummylabel1',
+                    'text': 'dummytext1'
+                },
+                {
+                    'ontology': 'UBERON:0002386',
+                    'ontology_label': 'dummylabel2',
+                    'text': 'dummytext2'
+                }
+            ]
+        })
+
+        self.metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [self.metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        self.flattened_metadata_entity['Project']['values'][0].update({
+            'project.organ_parts.ontology': 'UBERON:0000376||UBERON:0002386',
+            'project.organ_parts.ontology_label': 'dummylabel1||dummylabel2',
+            'project.organ_parts.text': 'dummytext1||dummytext2',
+
+        })
+        self.flattened_metadata_entity['Project']['headers'].extend(
+            [
+                'project.organ_parts.ontology',
+                'project.organ_parts.ontology_label',
+                'project.organ_parts.text'
+            ]
+        )
+
+        # then
+        self.assertEqual(actual, self.flattened_metadata_entity)
+
+    def test_flatten__has_ontology_property_with_multiple_elements_but_inconsistent_columns(self):
+        # given
+        self.content.update(
+            {'diseases': [
+                {
+                    'ontology': 'UBERON:0000376',
+                    'ontology_label': 'dummylabel1',
+                    'text': 'dummytext1'
+                },
+                {
+                    'text': 'dummytext2'
+                }
+            ]})
+
+        metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        self.flattened_metadata_entity['Project']['values'][0].update({
+            'project.diseases.ontology': 'UBERON:0000376',
+            'project.diseases.ontology_label': 'dummylabel1',
+            'project.diseases.text': 'dummytext1||dummytext2',
+
+        })
+        self.flattened_metadata_entity['Project']['headers'].extend(
+            [
+                'project.diseases.ontology',
+                'project.diseases.ontology_label',
+                'project.diseases.text'
+            ]
+        )
+
+        # then
+        self.assertEqual(actual, self.flattened_metadata_entity)
+
+    def test_flatten__has_ontology_property_with_multiple_elements_but_with_empty_ontology_values(self):
+        # given
+        self.content.update(
+            {'diseases': [
+                {
+                    'ontology': 'UBERON:0000376',
+                    'ontology_label': 'dummylabel1',
+                    'text': 'dummytext1'
+                },
+                {
+                    'ontology': '',
+                    'ontology_label': '',
+                    'text': 'dummytext2'
+                }
+            ]})
+
+        metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        self.flattened_metadata_entity['Project']['values'][0].update({
+            'project.diseases.ontology': 'UBERON:0000376',
+            'project.diseases.ontology_label': 'dummylabel1',
+            'project.diseases.text': 'dummytext1||dummytext2',
+
+        })
+        self.flattened_metadata_entity['Project']['headers'].extend(
+            [
+                'project.diseases.ontology',
+                'project.diseases.ontology_label',
+                'project.diseases.text'
+            ]
+        )
+
+        # then
+        self.assertEqual(self.flattened_metadata_entity, actual)
+
+    def test_flatten__has_ontology_property_with_single_element_but_only_with_text_attr(self):
+        # given
+        self.content.update(
+            {'diseases': [
+                {
+                    'text': 'dummytext2'
+                }
+            ]})
+
+        metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        self.flattened_metadata_entity['Project']['values'][0].update({
+            'project.diseases.text': 'dummytext2',
+
+        })
+        self.flattened_metadata_entity['Project']['headers'].extend(
+            [
+                'project.diseases.text'
+            ]
+        )
+
+        # then
+        self.assertEqual(actual, self.flattened_metadata_entity)
+
+    def test_flatten__has_ontology_property_with_single_element(self):
+        # given
+        self.content.update({
+            "organ_parts": [{
+                "ontology": "UBERON:0000376",
+                "ontology_label": "hindlimb stylopod",
+                "text": "hindlimb stylopod"
+            }]
+        })
+
+        metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        self.flattened_metadata_entity['Project']['values'][0].update({
+            'project.organ_parts.ontology': 'UBERON:0000376',
+            'project.organ_parts.ontology_label': 'hindlimb stylopod',
+            'project.organ_parts.text': 'hindlimb stylopod',
+
+        })
+        self.flattened_metadata_entity['Project']['headers'].extend([
+            'project.organ_parts.ontology',
+            'project.organ_parts.ontology_label',
+            'project.organ_parts.text'
+        ])
+
+        # then
+        self.assertEqual(actual, self.flattened_metadata_entity)

--- a/tests/unit/downloader/test_flatten_project_module.py
+++ b/tests/unit/downloader/test_flatten_project_module.py
@@ -1,0 +1,62 @@
+from ingest.downloader.flattener import Flattener
+from tests.unit.downloader.test_flattener import FlattenerTest
+
+
+class FlattenProjectModuleTest(FlattenerTest):
+    def test_flatten__has_project_modules(self):
+        # given
+        self.content.update({
+            "contributors": [{
+                "name": "Alex A,,Pollen",
+                "email": "alex.pollen@ucsf.edu",
+                "institution": "University of California, San Francisco (UCSF)",
+                "laboratory": "Department of Neurology",
+                "country": "USA",
+                "corresponding_contributor": True,
+                "project_role": {
+                    "text": "experimental scientist",
+                    "ontology": "EFO:0009741",
+                    "ontology_label": "experimental scientist"
+                }
+            }]
+        })
+
+        metadata_entity = {
+            'content': self.content,
+            'uuid': self.uuid
+        }
+
+        entity_list = [metadata_entity]
+
+        # when
+        flattener = Flattener()
+        actual = flattener.flatten(entity_list)
+
+        self.flattened_metadata_entity.update({
+            'Project - Contributors': {
+                'headers': [
+                    'project.contributors.name',
+                    'project.contributors.email',
+                    'project.contributors.institution',
+                    'project.contributors.laboratory',
+                    'project.contributors.country',
+                    'project.contributors.corresponding_contributor',
+                    'project.contributors.project_role.text',
+                    'project.contributors.project_role.ontology',
+                    'project.contributors.project_role.ontology_label'
+                ],
+                'values': [{
+                    'project.contributors.corresponding_contributor': 'True',
+                    'project.contributors.country': 'USA',
+                    'project.contributors.email': 'alex.pollen@ucsf.edu',
+                    'project.contributors.institution': 'University of California, San Francisco (UCSF)',
+                    'project.contributors.laboratory': 'Department of Neurology',
+                    'project.contributors.name': 'Alex A,,Pollen',
+                    'project.contributors.project_role.ontology': 'EFO:0009741',
+                    'project.contributors.project_role.ontology_label': 'experimental scientist',
+                    'project.contributors.project_role.text': 'experimental scientist'}
+                ]}
+        })
+
+        # then
+        self.assertEqual(actual, self.flattened_metadata_entity)

--- a/tests/unit/downloader/test_flattener.py
+++ b/tests/unit/downloader/test_flattener.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest import TestCase
 
 from ingest.downloader.flattener import Flattener
@@ -6,45 +7,25 @@ from ingest.downloader.flattener import Flattener
 
 class FlattenerTest(TestCase):
     def setUp(self) -> None:
-        self.content = {
-            "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/project",
-            "schema_type": "project",
-            "project_core": {
-                "project_short_name": "label",
-                "project_title": "title",
-                "project_description": "desc"
-            }
-        }
+        self.script_dir = os.path.dirname(__file__)
+
+        with open(self.script_dir + '/content.json') as file:
+            self.content = json.load(file)
 
         self.uuid = {
             'uuid': 'uuid1'
         }
 
-        self.flattened_metadata_entity = {
-            'Project': {
-                'headers': ['project.uuid', 'project.project_core.project_short_name',
-                            'project.project_core.project_title', 'project.project_core.project_description'],
-                'values': [
-                    {
-                        'project.uuid': 'uuid1',
-                        'project.project_core.project_short_name': 'label',
-                        'project.project_core.project_title': 'title',
-                        'project.project_core.project_description': 'desc'
-                    }
-                ]
-            },
-            'Schemas': [
-                'https://schema.humancellatlas.org/type/project/14.2.0/project'
-            ]
-        }
+        with open(self.script_dir + '/content-flattened.json') as file:
+            self.flattened_metadata_entity = json.load(file)
 
     def test_flatten__has_no_modules(self):
         # given
-        self.metadata_entity = {
+        metadata_entity = {
             'content': self.content,
             'uuid': self.uuid
         }
-        entity_list = [self.metadata_entity]
+        entity_list = [metadata_entity]
 
         # when
         flattener = Flattener()
@@ -88,8 +69,8 @@ class FlattenerTest(TestCase):
 
     def test_flatten__has_project_modules(self):
         # given
-        self.content.update({"contributors": [
-            {
+        self.content.update({
+            "contributors": [{
                 "name": "Alex A,,Pollen",
                 "email": "alex.pollen@ucsf.edu",
                 "institution": "University of California, San Francisco (UCSF)",
@@ -101,14 +82,15 @@ class FlattenerTest(TestCase):
                     "ontology": "EFO:0009741",
                     "ontology_label": "experimental scientist"
                 }
-            }
-        ]})
-        self.metadata_entity = {
+            }]
+        })
+
+        metadata_entity = {
             'content': self.content,
             'uuid': self.uuid
         }
 
-        entity_list = [self.metadata_entity]
+        entity_list = [metadata_entity]
 
         # when
         flattener = Flattener()
@@ -127,58 +109,18 @@ class FlattenerTest(TestCase):
                     'project.contributors.project_role.ontology',
                     'project.contributors.project_role.ontology_label'
                 ],
-                'values': [
-                    {'project.contributors.corresponding_contributor': 'True',
-                     'project.contributors.country': 'USA',
-                     'project.contributors.email': 'alex.pollen@ucsf.edu',
-                     'project.contributors.institution': 'University of California, San Francisco (UCSF)',
-                     'project.contributors.laboratory': 'Department of Neurology',
-                     'project.contributors.name': 'Alex A,,Pollen',
-                     'project.contributors.project_role.ontology': 'EFO:0009741',
-                     'project.contributors.project_role.ontology_label': 'experimental scientist',
-                     'project.contributors.project_role.text': 'experimental scientist'}
-                ]
-            }
+                'values': [{
+                    'project.contributors.corresponding_contributor': 'True',
+                    'project.contributors.country': 'USA',
+                    'project.contributors.email': 'alex.pollen@ucsf.edu',
+                    'project.contributors.institution': 'University of California, San Francisco (UCSF)',
+                    'project.contributors.laboratory': 'Department of Neurology',
+                    'project.contributors.name': 'Alex A,,Pollen',
+                    'project.contributors.project_role.ontology': 'EFO:0009741',
+                    'project.contributors.project_role.ontology_label': 'experimental scientist',
+                    'project.contributors.project_role.text': 'experimental scientist'}
+                ]}
         })
-
-        # then
-        self.assertEqual(actual, self.flattened_metadata_entity)
-
-    def test_flatten__has_ontology_property_with_single_element(self):
-        # given
-        self.content.update(
-            {"organ_parts": [
-                {
-                    "ontology": "UBERON:0000376",
-                    "ontology_label": "hindlimb stylopod",
-                    "text": "hindlimb stylopod"
-                }
-            ]})
-
-        self.metadata_entity = {
-            'content': self.content,
-            'uuid': self.uuid
-        }
-
-        entity_list = [self.metadata_entity]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        self.flattened_metadata_entity['Project']['values'][0].update({
-            'project.organ_parts.ontology': 'UBERON:0000376',
-            'project.organ_parts.ontology_label': 'hindlimb stylopod',
-            'project.organ_parts.text': 'hindlimb stylopod',
-
-        })
-        self.flattened_metadata_entity['Project']['headers'].extend(
-            [
-                'project.organ_parts.ontology',
-                'project.organ_parts.ontology_label',
-                'project.organ_parts.text'
-            ]
-        )
 
         # then
         self.assertEqual(actual, self.flattened_metadata_entity)
@@ -197,203 +139,42 @@ class FlattenerTest(TestCase):
             ]
         }
 
-        self.metadata_entity = {
-            'content': self.content,
+        metadata_entity = {
+            'content': content,
             'uuid': self.uuid
         }
 
-        entity_list = [self.metadata_entity]
+        entity_list = [metadata_entity]
 
         # when
         flattener = Flattener()
         actual = flattener.flatten(entity_list)
         flattened_metadata_entity = {
-            'Collection Protocol': {
-                'values': [{
-
-                }],
+            'Collection protocol': {
+                'values': [{}],
                 'headers': []
             }
         }
-        flattened_metadata_entity['Collection Protocol']['values'][0].update({
+        flattened_metadata_entity['Collection protocol']['values'][0].update({
             'collection_protocol.organ_parts.field_1': 'UBERON:0000376',
             'collection_protocol.organ_parts.field_2': 'hindlimb stylopod',
             'collection_protocol.organ_parts.field_3': 'hindlimb stylopod',
-
+            'collection_protocol.uuid': 'uuid1'
         })
-        flattened_metadata_entity['Collection Protocol']['headers'].extend(
+        flattened_metadata_entity['Collection protocol']['headers'].extend(
             [
+                'collection_protocol.uuid',
                 'collection_protocol.organ_parts.field_1',
                 'collection_protocol.organ_parts.field_2',
                 'collection_protocol.organ_parts.field_3'
             ]
         )
+        flattened_metadata_entity['Schemas'] = [
+            'https://schema.humancellatlas.org/type/project/14.2.0/collection_protocol'
+        ]
 
         # then
-        self.assertEqual(actual, self.flattened_metadata_entity)
-
-    def test_flatten__has_ontology_property_with_multiple_elements(self):
-        # given
-        self.content.update(
-            {'organ_parts': [
-                {
-                    'ontology': 'UBERON:0000376',
-                    'ontology_label': 'dummylabel1',
-                    'text': 'dummytext1'
-                },
-                {
-                    'ontology': 'UBERON:0002386',
-                    'ontology_label': 'dummylabel2',
-                    'text': 'dummytext2'
-                }
-            ]})
-
-        self.metadata_entity = {
-            'content': self.content,
-            'uuid': self.uuid
-        }
-
-        entity_list = [self.metadata_entity]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        self.flattened_metadata_entity['Project']['values'][0].update({
-            'project.organ_parts.ontology': 'UBERON:0000376||UBERON:0002386',
-            'project.organ_parts.ontology_label': 'dummylabel1||dummylabel2',
-            'project.organ_parts.text': 'dummytext1||dummytext2',
-
-        })
-        self.flattened_metadata_entity['Project']['headers'].extend(
-            [
-                'project.organ_parts.ontology',
-                'project.organ_parts.ontology_label',
-                'project.organ_parts.text'
-            ]
-        )
-
-        # then
-        self.assertEqual(actual, self.flattened_metadata_entity)
-
-    def test_flatten__has_ontology_property_with_multiple_elements_but_inconsistent_columns(self):
-        # given
-        self.content.update(
-            {'diseases': [
-                {
-                    'ontology': 'UBERON:0000376',
-                    'ontology_label': 'dummylabel1',
-                    'text': 'dummytext1'
-                },
-                {
-                    'text': 'dummytext2'
-                }
-            ]})
-
-        self.metadata_entity = {
-            'content': self.content,
-            'uuid': self.uuid
-        }
-
-        entity_list = [self.metadata_entity]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        self.flattened_metadata_entity['Project']['values'][0].update({
-            'project.diseases.ontology': 'UBERON:0000376',
-            'project.diseases.ontology_label': 'dummylabel1',
-            'project.diseases.text': 'dummytext1||dummytext2',
-
-        })
-        self.flattened_metadata_entity['Project']['headers'].extend(
-            [
-                'project.diseases.ontology',
-                'project.diseases.ontology_label',
-                'project.diseases.text'
-            ]
-        )
-
-        # then
-        self.assertEqual(actual, self.flattened_metadata_entity)
-
-    def test_flatten__has_ontology_property_with_multiple_elements_but_with_empty_ontology_values(self):
-        # given
-        self.content.update(
-            {'diseases': [
-                {
-                    'ontology': 'UBERON:0000376',
-                    'ontology_label': 'dummylabel1',
-                    'text': 'dummytext1'
-                },
-                {
-                    'ontology': '',
-                    'ontology_label': '',
-                    'text': 'dummytext2'
-                }
-            ]})
-
-        self.metadata_entity = {
-            'content': self.content,
-            'uuid': self.uuid
-        }
-
-        entity_list = [self.metadata_entity]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        self.flattened_metadata_entity['Project']['values'][0].update({
-            'project.diseases.ontology': 'UBERON:0000376',
-            'project.diseases.ontology_label': 'dummylabel1',
-            'project.diseases.text': 'dummytext1||dummytext2',
-
-        })
-        self.flattened_metadata_entity['Project']['headers'].extend(
-            [
-                'project.diseases.ontology',
-                'project.diseases.ontology_label',
-                'project.diseases.text'
-            ]
-        )
-
-        # then
-        self.assertEqual(self.flattened_metadata_entity, actual)
-
-    def test_flatten__has_ontology_property_with_single_element_but_only_with_text_attr(self):
-        # given
-        self.content.update(
-            {'diseases': [
-                {
-                    'text': 'dummytext2'
-                }
-            ]})
-
-        self.metadata_entity = {
-            'content': self.content,
-            'uuid': self.uuid
-        }
-
-        entity_list = [self.metadata_entity]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        self.flattened_metadata_entity['Project']['values'][0].update({
-            'project.diseases.text': 'dummytext2',
-
-        })
-        self.flattened_metadata_entity['Project']['headers'].extend(
-            [
-                'project.diseases.text'
-            ]
-        )
-
-        # then
-        self.assertEqual(actual, self.flattened_metadata_entity)
+        self.assertEqual(actual, flattened_metadata_entity)
 
     def test_flatten__has_boolean(self):
         # given
@@ -454,154 +235,6 @@ class FlattenerTest(TestCase):
             },
             'Schemas': [
                 'https://schema.humancellatlas.org/type/project/14.2.0/project'
-            ]
-        }
-
-        # then
-        self.assertEqual(actual, expected)
-
-    def test_flatten__project_metadata(self):
-        self.maxDiff = None
-
-        # given
-        with open('project-list.json') as file:
-            entity_list = json.load(file)
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        with open('project-list-flattened.json') as file:
-            expected = json.load(file)
-
-        # then
-        self.assertEqual(actual, expected)
-
-    def test_flatten__has_different_entities(self):
-        # given
-        entity_list = [{
-            'content': {
-                "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/project",
-                "schema_type": "project",
-                "project_core": {
-                    "project_short_name": "label",
-                    "project_title": "title",
-                    "project_description": "desc"
-                },
-                "contributors": [
-                    {
-                        "name": "Alex A,,Pollen",
-                        "email": "alex.pollen@ucsf.edu",
-                        "institution": "University of California, San Francisco (UCSF)",
-                        "laboratory": "Department of Neurology",
-                        "country": "USA",
-                        "corresponding_contributor": True,
-                        "project_role": {
-                            "text": "experimental scientist",
-                            "ontology": "EFO:0009741",
-                            "ontology_label": "experimental scientist"
-                        }
-                    }
-                ]
-            },
-            'uuid': {
-                'uuid': 'uuid1'
-            }
-        },
-            {
-                'content': {
-                    "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/donor_organism",
-                    "schema_type": "biomaterial",
-                    "biomaterial_core": {
-                        "biomaterial_id": "label",
-                        "biomaterial_description": "desc"
-                    }
-                },
-                'uuid': {
-                    'uuid': 'uuid2'
-                }
-            },
-            {
-                'content': {
-                    "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/donor_organism",
-                    "schema_type": "biomaterial",
-                    "biomaterial_core": {
-                        "biomaterial_id": "label",
-                        "biomaterial_description": "desc"
-                    }
-                },
-                'uuid': {
-                    'uuid': 'uuid3'
-                }
-            }
-        ]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        expected = {
-            'Project': {
-                'headers': [
-                    'project.uuid',
-                    'project.project_core.project_short_name',
-                    'project.project_core.project_title',
-                    'project.project_core.project_description'
-                ],
-                'values': [
-                    {
-                        'project.uuid': 'uuid1',
-                        'project.project_core.project_short_name': 'label',
-                        'project.project_core.project_title': 'title',
-                        'project.project_core.project_description': 'desc'
-                    }
-                ]},
-            'Project - Contributors': {
-                'headers': [
-                    'project.contributors.name',
-                    'project.contributors.email',
-                    'project.contributors.institution',
-                    'project.contributors.laboratory',
-                    'project.contributors.country',
-                    'project.contributors.corresponding_contributor',
-                    'project.contributors.project_role.text',
-                    'project.contributors.project_role.ontology',
-                    'project.contributors.project_role.ontology_label'
-                ],
-                'values': [
-                    {'project.contributors.corresponding_contributor': 'True',
-                     'project.contributors.country': 'USA',
-                     'project.contributors.email': 'alex.pollen@ucsf.edu',
-                     'project.contributors.institution': 'University of California, San Francisco (UCSF)',
-                     'project.contributors.laboratory': 'Department of Neurology',
-                     'project.contributors.name': 'Alex A,,Pollen',
-                     'project.contributors.project_role.ontology': 'EFO:0009741',
-                     'project.contributors.project_role.ontology_label': 'experimental scientist',
-                     'project.contributors.project_role.text': 'experimental scientist'}
-                ]
-            },
-            'Donor organism': {
-                'headers': [
-                    'donor_organism.uuid',
-                    'donor_organism.biomaterial_core.biomaterial_id',
-                    'donor_organism.biomaterial_core.biomaterial_description'
-                ],
-                'values': [
-                    {
-                        'donor_organism.uuid': 'uuid2',
-                        'donor_organism.biomaterial_core.biomaterial_id': 'label',
-                        'donor_organism.biomaterial_core.biomaterial_description': 'desc'
-                    },
-                    {
-                        'donor_organism.uuid': 'uuid3',
-                        'donor_organism.biomaterial_core.biomaterial_id': 'label',
-                        'donor_organism.biomaterial_core.biomaterial_description': 'desc'
-                    }
-                ]
-            },
-            'Schemas': [
-                'https://schema.humancellatlas.org/type/project/14.2.0/project',
-                'https://schema.humancellatlas.org/type/project/14.2.0/donor_organism'
             ]
         }
 
@@ -673,21 +306,6 @@ class FlattenerTest(TestCase):
         # then
         self.assertEqual(actual, expected)
 
-    def test_flatten__collection_protocol_metadata(self):
-        # given
-        with open('collection_protocol-list.json') as file:
-            entity_list = json.load(file)
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        with open('collection_protocol-list-flattened.json') as file:
-            expected = json.load(file)
-
-        # then
-        self.assertEqual(actual, expected)
-
     def test_flatten__raises_error__given_multiple_schema_versions_of_same_concrete_entity(self):
         # given
         entity_list = [
@@ -718,4 +336,3 @@ class FlattenerTest(TestCase):
         flattener = Flattener()
         with self.assertRaisesRegex(ValueError, "Multiple versions of same concrete entity schema"):
             flattener.flatten(entity_list)
-

--- a/tests/unit/downloader/test_flattener.py
+++ b/tests/unit/downloader/test_flattener.py
@@ -67,65 +67,7 @@ class FlattenerTest(TestCase):
 
         self.assertEqual(actual, self.flattened_metadata_entity)
 
-    def test_flatten__has_project_modules(self):
-        # given
-        self.content.update({
-            "contributors": [{
-                "name": "Alex A,,Pollen",
-                "email": "alex.pollen@ucsf.edu",
-                "institution": "University of California, San Francisco (UCSF)",
-                "laboratory": "Department of Neurology",
-                "country": "USA",
-                "corresponding_contributor": True,
-                "project_role": {
-                    "text": "experimental scientist",
-                    "ontology": "EFO:0009741",
-                    "ontology_label": "experimental scientist"
-                }
-            }]
-        })
-
-        metadata_entity = {
-            'content': self.content,
-            'uuid': self.uuid
-        }
-
-        entity_list = [metadata_entity]
-
-        # when
-        flattener = Flattener()
-        actual = flattener.flatten(entity_list)
-
-        self.flattened_metadata_entity.update({
-            'Project - Contributors': {
-                'headers': [
-                    'project.contributors.name',
-                    'project.contributors.email',
-                    'project.contributors.institution',
-                    'project.contributors.laboratory',
-                    'project.contributors.country',
-                    'project.contributors.corresponding_contributor',
-                    'project.contributors.project_role.text',
-                    'project.contributors.project_role.ontology',
-                    'project.contributors.project_role.ontology_label'
-                ],
-                'values': [{
-                    'project.contributors.corresponding_contributor': 'True',
-                    'project.contributors.country': 'USA',
-                    'project.contributors.email': 'alex.pollen@ucsf.edu',
-                    'project.contributors.institution': 'University of California, San Francisco (UCSF)',
-                    'project.contributors.laboratory': 'Department of Neurology',
-                    'project.contributors.name': 'Alex A,,Pollen',
-                    'project.contributors.project_role.ontology': 'EFO:0009741',
-                    'project.contributors.project_role.ontology_label': 'experimental scientist',
-                    'project.contributors.project_role.text': 'experimental scientist'}
-                ]}
-        })
-
-        # then
-        self.assertEqual(actual, self.flattened_metadata_entity)
-
-    def test_flatten__has_property_with_elements(self):
+    def test_flatten__has_list_property_with_elements(self):
         # given
         content = {
             "describedBy": "https://schema.humancellatlas.org/type/project/14.2.0/collection_protocol",
@@ -149,29 +91,26 @@ class FlattenerTest(TestCase):
         # when
         flattener = Flattener()
         actual = flattener.flatten(entity_list)
+
         flattened_metadata_entity = {
             'Collection protocol': {
-                'values': [{}],
-                'headers': []
-            }
-        }
-        flattened_metadata_entity['Collection protocol']['values'][0].update({
-            'collection_protocol.organ_parts.field_1': 'UBERON:0000376',
-            'collection_protocol.organ_parts.field_2': 'hindlimb stylopod',
-            'collection_protocol.organ_parts.field_3': 'hindlimb stylopod',
-            'collection_protocol.uuid': 'uuid1'
-        })
-        flattened_metadata_entity['Collection protocol']['headers'].extend(
-            [
-                'collection_protocol.uuid',
-                'collection_protocol.organ_parts.field_1',
-                'collection_protocol.organ_parts.field_2',
-                'collection_protocol.organ_parts.field_3'
+                'values': [{
+                    'collection_protocol.organ_parts.field_1': 'UBERON:0000376',
+                    'collection_protocol.organ_parts.field_2': 'hindlimb stylopod',
+                    'collection_protocol.organ_parts.field_3': 'hindlimb stylopod',
+                    'collection_protocol.uuid': 'uuid1'
+                }],
+                'headers': [
+                    'collection_protocol.uuid',
+                    'collection_protocol.organ_parts.field_1',
+                    'collection_protocol.organ_parts.field_2',
+                    'collection_protocol.organ_parts.field_3'
+                ]
+            },
+            'Schemas': [
+                'https://schema.humancellatlas.org/type/project/14.2.0/collection_protocol'
             ]
-        )
-        flattened_metadata_entity['Schemas'] = [
-            'https://schema.humancellatlas.org/type/project/14.2.0/collection_protocol'
-        ]
+        }
 
         # then
         self.assertEqual(actual, flattened_metadata_entity)
@@ -214,32 +153,14 @@ class FlattenerTest(TestCase):
         flattener = Flattener()
         actual = flattener.flatten(entity_list)
 
-        expected = {
-            'Project': {
-                'headers': [
-                    'project.uuid',
-                    'project.project_core.project_short_name',
-                    'project.project_core.project_title',
-                    'project.project_core.project_description',
-                    'project.int_field'
-                ],
-                'values': [
-                    {
-                        'project.uuid': 'uuid1',
-                        'project.project_core.project_short_name': 'label',
-                        'project.project_core.project_title': 'title',
-                        'project.project_core.project_description': 'desc',
-                        'project.int_field': '1'
-                    }
-                ]
-            },
-            'Schemas': [
-                'https://schema.humancellatlas.org/type/project/14.2.0/project'
-            ]
-        }
+        self.flattened_metadata_entity['Project']['values'][0].update({
+            'project.int_field': '1'
+        })
+
+        self.flattened_metadata_entity['Project']['headers'].append('project.int_field')
 
         # then
-        self.assertEqual(actual, expected)
+        self.assertEqual(actual, self.flattened_metadata_entity)
 
     def test_flatten__rows_have_different_columns(self):
         # given

--- a/tests/unit/downloader/test_flattener.py
+++ b/tests/unit/downloader/test_flattener.py
@@ -1,7 +1,7 @@
 import json
 from unittest import TestCase
 
-from ingest.downloader.flattener import Flattener, Error as FlattenerError
+from ingest.downloader.flattener import Flattener
 
 
 class FlattenerTest(TestCase):
@@ -716,6 +716,6 @@ class FlattenerTest(TestCase):
 
         # when/then
         flattener = Flattener()
-        with self.assertRaisesRegex(FlattenerError, "Multiple versions of same concrete entity schema"):
+        with self.assertRaisesRegex(ValueError, "Multiple versions of same concrete entity schema"):
             flattener.flatten(entity_list)
 

--- a/tests/unit/downloader/test_xls_generation.py
+++ b/tests/unit/downloader/test_xls_generation.py
@@ -4,7 +4,8 @@ import unittest
 from openpyxl import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
-from ingest.downloader.downloader import XlsDownloader, SCHEMAS_WORKSHEET
+from ingest.downloader.downloader import XlsDownloader
+from ingest.importer.spreadsheet.ingest_workbook import SCHEMAS_WORKSHEET
 
 
 class XLSGenerationTest(unittest.TestCase):

--- a/tests/unit/downloader/test_xls_generation.py
+++ b/tests/unit/downloader/test_xls_generation.py
@@ -14,20 +14,20 @@ class XLSGenerationTest(unittest.TestCase):
         self.workbook.create_sheet(title='Project')
 
     def test_given_input_has_only_1_set_of_data_successfully_creates_a_workbook(self):
-        #given
+        # given
         project_sheet_title = 'Project'
         input_json = self.__input_json1(project_sheet_title)
 
         # when
         workbook: Workbook = self.downloader.create_workbook(input_json)
 
-        #expect
-        self.assertEqual(len(workbook.worksheets), 1)
+        # expect
+        self.assertEqual(len(workbook.worksheets), 2)
 
         self.__assert_sheet(workbook, project_sheet_title, input_json)
 
     def test_given_input_has_many_rows_of_data_successfully_creates_a_workbook(self):
-        #given
+        # given
         contributors_sheet_title = 'Project - Contributors'
 
         input_json = self.__input_json2(contributors_sheet_title)
@@ -35,8 +35,8 @@ class XLSGenerationTest(unittest.TestCase):
         # when
         workbook: Workbook = self.downloader.create_workbook(input_json)
 
-        #expect
-        self.assertEqual(len(workbook.worksheets), 1)
+        # expect
+        self.assertEqual(len(workbook.worksheets), 2)
 
         self.__assert_sheet(workbook, contributors_sheet_title, input_json)
 
@@ -48,13 +48,31 @@ class XLSGenerationTest(unittest.TestCase):
         with open('project-list-flattened.json') as file:
             input_json = json.load(file)
 
-        #when
+        # when
         workbook: Workbook = self.downloader.create_workbook(input_json)
 
         # expect
-        self.assertEqual(len(workbook.worksheets), 4)
+        self.assertEqual(len(workbook.worksheets), 5)
 
         map(lambda title: self.__assert_sheet(workbook, title, input_json), sheet_titles)
+
+    def test_given_input_create_workbook_with_schemas_worksheet(self):
+        # given
+        with open('project-list-flattened.json') as file:
+            input_json = json.load(file)
+
+        # when
+        workbook: Workbook = self.downloader.create_workbook(input_json)
+
+        # expect
+        self.assertTrue('Schemas' in workbook.sheetnames)
+        sheet: Worksheet = workbook['Schemas']
+        rows_iter = sheet.iter_rows(min_col=1, min_row=1, max_col=1, max_row=sheet.max_row)
+        schemas = [[cell.value for cell in row] for row in rows_iter]
+        self.assertTrue(schema in input_json.get('Schemas') for schema in schemas)
+
+
+
 
     @staticmethod
     def __input_json1(project_sheet_title):
@@ -80,7 +98,8 @@ class XLSGenerationTest(unittest.TestCase):
                         "project.insdc_study_accessions": "PRJNA515930"
                     }
                 ]
-            }
+            },
+            "Schemas": ["dummy-schema-url"]
         }
 
     @staticmethod
@@ -141,7 +160,8 @@ class XLSGenerationTest(unittest.TestCase):
                         'project.contributors.orcid_id': 'https://orcid.org/0000-0000-0000-0001'
                     }
                 ]
-            }
+            },
+            "Schemas": ["dummy-schema-url"]
         }
 
     def __assert_sheet(self, workbook, sheet_title, input_json):

--- a/tests/unit/downloader/test_xls_generation.py
+++ b/tests/unit/downloader/test_xls_generation.py
@@ -71,8 +71,9 @@ class XLSGenerationTest(unittest.TestCase):
         schemas = [[cell.value for cell in row] for row in rows_iter]
         self.assertTrue(schema in schemas for schema in input_json.get('Schemas'))
 
-
-
+    def test_given_input_raises_error_when_no_schemas_worksheet(self):
+        with self.assertRaisesRegex(ValueError, "The schema urls are missing"):
+            self.downloader.create_workbook({})
 
     @staticmethod
     def __input_json1(project_sheet_title):

--- a/tests/unit/downloader/test_xls_generation.py
+++ b/tests/unit/downloader/test_xls_generation.py
@@ -69,7 +69,7 @@ class XLSGenerationTest(unittest.TestCase):
         sheet: Worksheet = workbook['Schemas']
         rows_iter = sheet.iter_rows(min_col=1, min_row=1, max_col=1, max_row=sheet.max_row)
         schemas = [[cell.value for cell in row] for row in rows_iter]
-        self.assertTrue(schema in input_json.get('Schemas') for schema in schemas)
+        self.assertTrue(schema in schemas for schema in input_json.get('Schemas'))
 
 
 

--- a/tests/unit/downloader/test_xls_generation.py
+++ b/tests/unit/downloader/test_xls_generation.py
@@ -4,7 +4,7 @@ import unittest
 from openpyxl import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
-from ingest.downloader.downloader import XlsDownloader
+from ingest.downloader.downloader import XlsDownloader, SCHEMAS_WORKSHEET
 
 
 class XLSGenerationTest(unittest.TestCase):
@@ -65,11 +65,11 @@ class XLSGenerationTest(unittest.TestCase):
         workbook: Workbook = self.downloader.create_workbook(input_json)
 
         # expect
-        self.assertTrue('Schemas' in workbook.sheetnames)
-        sheet: Worksheet = workbook['Schemas']
+        self.assertTrue(SCHEMAS_WORKSHEET in workbook.sheetnames)
+        sheet: Worksheet = workbook[SCHEMAS_WORKSHEET]
         rows_iter = sheet.iter_rows(min_col=1, min_row=1, max_col=1, max_row=sheet.max_row)
         schemas = [[cell.value for cell in row] for row in rows_iter]
-        self.assertTrue(schema in schemas for schema in input_json.get('Schemas'))
+        self.assertTrue(schema in schemas for schema in input_json.get(SCHEMAS_WORKSHEET))
 
     def test_given_input_raises_error_when_no_schemas_worksheet(self):
         with self.assertRaisesRegex(ValueError, "The schema urls are missing"):

--- a/tests/unit/downloader/test_xls_generation.py
+++ b/tests/unit/downloader/test_xls_generation.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 
 from openpyxl import Workbook
@@ -10,6 +11,7 @@ from ingest.importer.spreadsheet.ingest_workbook import SCHEMAS_WORKSHEET
 
 class XLSGenerationTest(unittest.TestCase):
     def setUp(self) -> None:
+        self.script_dir = os.path.dirname(__file__)
         self.downloader = XlsDownloader()
         self.workbook = Workbook()
         self.workbook.create_sheet(title='Project')
@@ -46,7 +48,7 @@ class XLSGenerationTest(unittest.TestCase):
         sheet_titles = ['Project', 'Project - Contributors', 'Project - Publications', 'Project - Funders']
 
         # when
-        with open('project-list-flattened.json') as file:
+        with open(self.script_dir + '/project-list-flattened.json') as file:
             input_json = json.load(file)
 
         # when
@@ -59,7 +61,7 @@ class XLSGenerationTest(unittest.TestCase):
 
     def test_given_input_create_workbook_with_schemas_worksheet(self):
         # given
-        with open('project-list-flattened.json') as file:
+        with open(self.script_dir + '/project-list-flattened.json') as file:
             input_json = json.load(file)
 
         # when


### PR DESCRIPTION
related to ebi-ait/dcp-ingest-central#455

Background info on the Importer: When the importer sees that there is a "Schemas" worksheet, it reads the list of schema URLs there and use them in parsing and creating JSON's for each row of the spreadsheet. If there is no "Schemas" worksheet, it sends a request to Ingest Core API to know what the latest schema URLs are. This is the reason why the entities get updated with the latest version when updating from the downloaded spreadsheet. The downloaded spreadsheet should contain the schema URLs to be used in the importer.

This change will include the generation of the Schemas tab when downloading spreadsheet.