### PR TITLE
dcp-804 Add requests-cache and configurable page sizes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
 stages:
@@ -24,8 +24,8 @@ Unit Tests:
 
 Test PyPI Deployment:
   stage: testpypi
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  except:
+   - external_pull_request_event
   script:
     - python setup.py sdist
     - TWINE_PASSWORD=$PYPI_TEST_API_TOKEN TWINE_USERNAME=__token__ python3 -m twine upload --repository testpypi dist/*
@@ -36,6 +36,9 @@ Test PyPI Deployment:
 PyPI Deployment:
   stage: pypi
   when: manual
+  except:
+   - external_pull_request_event
+  allow_failure: false
   dependencies:
     - Test PyPI Deployment
   script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://travis-ci.org/HumanCellAtlas/ingest-client.svg?branch=master)](https://travis-ci.org/HumanCellAtlas/ingest-client)
-[![Maintainability](https://api.codeclimate.com/v1/badges/2fba112abcaba6d7bcda/maintainability)](https://codeclimate.com/github/HumanCellAtlas/ingest-client/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/2fba112abcaba6d7bcda/test_coverage)](https://codeclimate.com/github/HumanCellAtlas/ingest-client/test_coverage)
 [![PyPI](https://img.shields.io/pypi/v/hca-ingest.svg)](https://pypi.org/project/hca-ingest/)
 
 # Ingest Client

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -4,3 +4,4 @@ mock
 coverage
 sortedcontainers
 twine
+requests-mock

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,5 +1,6 @@
 -c requirements.txt
 flake8==3.5.0
 mock
+coverage
 sortedcontainers
 twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -56,7 +56,9 @@ rfc3986==2.0.0
 rich==12.5.1
     # via twine
 six==1.16.0
-    # via bleach
+    # via
+    #   -c requirements.txt
+    #   bleach
 sortedcontainers==2.4.0
     # via
     #   -c requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,8 @@ charset-normalizer==2.1.0
     #   requests
 commonmark==0.9.1
     # via rich
+coverage==6.4.3
+    # via -r dev-requirements.in
 docutils==0.19
     # via readme-renderer
 flake8==3.5.0
@@ -26,7 +28,7 @@ idna==3.3
     #   requests
 importlib-metadata==4.12.0
     # via twine
-keyring==23.7.0
+keyring==23.8.2
     # via twine
 mccabe==0.6.1
     # via flake8
@@ -42,7 +44,7 @@ pygments==2.12.0
     # via
     #   readme-renderer
     #   rich
-readme-renderer==35.0
+readme-renderer==36.0
     # via twine
 requests[security]==2.28.1
     # via

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,8 +49,11 @@ readme-renderer==36.0
 requests[security]==2.28.1
     # via
     #   -c requirements.txt
+    #   requests-mock
     #   requests-toolbelt
     #   twine
+requests-mock==1.9.3
+    # via -r dev-requirements.in
 requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
@@ -61,6 +64,7 @@ six==1.16.0
     # via
     #   -c requirements.txt
     #   bleach
+    #   requests-mock
 sortedcontainers==2.4.0
     # via
     #   -c requirements.txt

--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -127,8 +127,8 @@ class IngestApi:
         schema_url = self.get_schemas_url()
         if latest_only:
             search_url = self.get_link_from_resource_url(schema_url, "search")
-            response_j = self.get(search_url).json()
-            all_schemas = list(self.get_related_entities("latestSchemas", response_j, "schemas"))
+            response_json = self.get(search_url).json()
+            all_schemas = list(self.get_related_entities("latestSchemas", response_json, "schemas"))
         else:
             all_schemas = list(self.get_entities(schema_url, "schemas"))
 

--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -105,8 +105,8 @@ class IngestApi:
     def _get_ingest_links(self):
         return self.get(self.url).json()["_links"]
 
-    def get_link_from_resource_url(self, resource_url, link_name, headers=None):
-        links = self.get(resource_url, headers=headers).json().get('_links', {})
+    def get_link_from_resource_url(self, resource_url, link_name):
+        links = self.get(resource_url).json().get('_links', {})
         return links.get(link_name, {}).get('href')
 
     @staticmethod
@@ -203,8 +203,7 @@ class IngestApi:
         return self.get(submission_url).json()
 
     def get_submission_by_uuid(self, submission_uuid):
-        headers = self.__get_basic_header()
-        search_link = self.get_link_from_resource_url(self.url + '/submissionEnvelopes/search', 'findByUuid', headers)
+        search_link = self.get_link_from_resource_url(self.url + '/submissionEnvelopes/search', 'findByUuid')
         search_link = search_link.replace('{?uuid}', '')  # TODO: use a REST traverser instead of requests?
         return self.get(search_link, params={'uuid': submission_uuid}).json()
 

--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -14,9 +14,9 @@ from hca_ingest.api.requests_utils import create_session_with_retry
 
 
 class IngestApi:
-    def __init__(self, url=None, token_manager=None):
+    def __init__(self, url=None, token_manager=None, session=None):
         self.logger = logging.getLogger(__name__)
-        self.session = create_session_with_retry()
+        self.session = session if session else create_session_with_retry()
         self.token_manager = token_manager
 
         if not url and 'INGEST_API' in os.environ:

--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -71,7 +71,7 @@ class IngestApi:
         if 'headers' not in kwargs:
             kwargs['headers'] = self.get_headers()
         response = self.session.patch(url, json=patch, **kwargs)
-        self.session.cache.delete_url(url)
+        self.session.cache.clear()
         response.raise_for_status()
         return response
 
@@ -80,7 +80,7 @@ class IngestApi:
             kwargs['headers'] = self.get_headers()
 
         response = self.session.put(url, **kwargs)
-        self.session.cache.delete_url(url)
+        self.session.cache.clear()
         response.raise_for_status()
         return response
 
@@ -89,7 +89,7 @@ class IngestApi:
             kwargs['headers'] = self.get_headers()
 
         response = self.session.post(url, **kwargs)
-        self.session.cache.delete_url(url)
+        self.session.cache.clear()
         response.raise_for_status()
         return response
 
@@ -98,7 +98,7 @@ class IngestApi:
             kwargs['headers'] = self.get_headers()
 
         response = self.session.delete(url, **kwargs)
-        self.session.cache.delete_url(url)
+        self.session.cache.clear()
         response.raise_for_status()
         return response
 

--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -63,44 +63,44 @@ class IngestApi:
     def get(self, url, **kwargs):
         if 'headers' not in kwargs:
             kwargs['headers'] = self.get_headers()
-        r = self.session.get(url, **kwargs)
-        r.raise_for_status()
-        return r
+        response = self.session.get(url, **kwargs)
+        response.raise_for_status()
+        return response
 
     def patch(self, url, patch, **kwargs):
         if 'headers' not in kwargs:
             kwargs['headers'] = self.get_headers()
-        r = self.session.patch(url, json=patch, **kwargs)
+        response = self.session.patch(url, json=patch, **kwargs)
         self.session.cache.delete_url(url)
-        r.raise_for_status()
-        return r
+        response.raise_for_status()
+        return response
 
     def put(self, url, data, **kwargs):
         if 'headers' not in kwargs:
             kwargs['headers'] = self.get_headers()
 
-        r = self.session.put(url, json=data, **kwargs)
+        response = self.session.put(url, json=data, **kwargs)
         self.session.cache.delete_url(url)
-        r.raise_for_status()
-        return r
+        response.raise_for_status()
+        return response
 
     def post(self, url, data, **kwargs):
         if 'headers' not in kwargs:
             kwargs['headers'] = self.get_headers()
 
-        r = self.session.post(url, json=data, **kwargs)
+        response = self.session.post(url, json=data, **kwargs)
         self.session.cache.delete_url(url)
-        r.raise_for_status()
-        return r
+        response.raise_for_status()
+        return response
 
     def delete(self, url, **kwargs):
         if 'headers' not in kwargs:
             kwargs['headers'] = self.get_headers()
 
-        r = self.session.delete(url, **kwargs)
+        response = self.session.delete(url, **kwargs)
         self.session.cache.delete_url(url)
-        r.raise_for_status()
-        return r
+        response.raise_for_status()
+        return response
 
     def _get_ingest_links(self):
         return self.get(self.url).json()["_links"]
@@ -335,7 +335,7 @@ class IngestApi:
 
         # Do not use session retries here as it will throw requests.exceptions.RetryError for http 409 error
         # We want to retry that error when creating files by doing a subsequent PATCH requests to update the metadata
-        r = requests.post(
+        response = requests.post(
             submission_files_url,
             json=file_to_create_object,
             params=params,
@@ -343,7 +343,7 @@ class IngestApi:
         )
 
         # TODO Investigate why core is returning internal server error
-        if r.status_code == requests.codes.conflict or r.status_code == requests.codes.internal_server_error:
+        if response.status_code == requests.codes.conflict or response.status_code == requests.codes.internal_server_error:
             search_files = self.get_file_by_submission_url_and_filename(submission_url, filename)
 
             if search_files and search_files.get('_embedded') and search_files['_embedded'].get('files'):
@@ -358,12 +358,12 @@ class IngestApi:
 
                 file_url = file_in_ingest['_links']['self']['href']
                 time.sleep(0.001)
-                r = self.patch(file_url, {'content': new_content})
+                response = self.patch(file_url, {'content': new_content})
                 self.logger.debug(f'Updating existing content of file {file_url}.')
 
-        r.raise_for_status()
+        response.raise_for_status()
 
-        return r.json()
+        return response.json()
 
     def create_submission_manifest(self, submission_url, data):
         return self.create_entity(submission_url, data, 'submissionManifest')

--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -106,7 +106,8 @@ class IngestApi:
         return self.get(self.url).json()["_links"]
 
     def get_link_from_resource_url(self, resource_url, link_name):
-        links = self.get(resource_url).json().get('_links', {})
+        params = {'size': 1}
+        links = self.get(resource_url, params=params).json().get('_links', {})
         return links.get(link_name, {}).get('href')
 
     @staticmethod

--- a/hca_ingest/api/requests_utils.py
+++ b/hca_ingest/api/requests_utils.py
@@ -1,9 +1,10 @@
-from requests import Session
+from datetime import timedelta
 from requests.adapters import HTTPAdapter
 from urllib3.util import retry
+from requests_cache import CachedSession
 
 
-def create_session_with_retry(retry_policy=None) -> Session:
+def create_session_with_retry(retry_policy=None) -> CachedSession:
     retry_policy = retry_policy or retry.Retry(
         total=50,
         # seems that this has a default value of 10,
@@ -18,7 +19,7 @@ def create_session_with_retry(retry_policy=None) -> Session:
         method_whitelist=frozenset(
             ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'])
     )
-    session = Session()
+    session = CachedSession(expire_after=timedelta(hours=2))
     adapter = HTTPAdapter(max_retries=retry_policy)
     session.mount('http://', adapter)
     session.mount('https://', adapter)

--- a/hca_ingest/api/stagingapi.py
+++ b/hca_ingest/api/stagingapi.py
@@ -15,7 +15,7 @@ from time import time
 from urllib.parse import urljoin
 
 import requests
-import requests.packages.urllib3.util.retry as retry
+import urllib3.util.retry as retry
 
 DEFAULT_STAGING_URL = os.environ.get('STAGING_API', 'https://upload.dev.data.humancellatlas.org')
 DEFAULT_STAGING_VERSION = os.environ.get('STAGING_API_VERSION', 'v1')

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-coverage
 dataclasses
 jsonref
 openpyxl

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ sortedcontainers
 mergedeep
 cryptography
 PyJWT
+requests-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,14 @@
 #
 #    pip-compile --output-file=- requirements.in
 #
+appdirs==1.4.4
+    # via requests-cache
+attrs==21.4.0
+    # via
+    #   cattrs
+    #   requests-cache
+cattrs==22.1.0
+    # via requests-cache
 certifi==2022.6.15
     # via requests
 cffi==1.15.1
@@ -18,6 +26,10 @@ dataclasses==0.6
     # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
+exceptiongroup==1.0.0rc8
+    # via
+    #   cattrs
+    #   requests-cache
 idna==3.3
     # via requests
 jsonref==0.2
@@ -35,10 +47,20 @@ pyjwt==2.4.0
 pyyaml==6.0
     # via -r requirements.in
 requests[security]==2.28.1
+    # via
+    #   -r requirements.in
+    #   requests-cache
+requests-cache==0.9.5
     # via -r requirements.in
+six==1.16.0
+    # via url-normalize
 sortedcontainers==2.4.0
     # via -r requirements.in
+url-normalize==1.4.3
+    # via requests-cache
 urllib3==1.26.11
-    # via requests
+    # via
+    #   requests
+    #   requests-cache
 xlsxwriter==3.0.3
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,6 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==2.1.0
     # via requests
-coverage==6.4.2
-    # via -r requirements.in
 cryptography==37.0.4
     # via -r requirements.in
 dataclasses==0.6

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as md:
 
 setup(
     name='hca-ingest',
-    version='2.0.1',
+    version='2.1.0',
     description='A library to communicate with the Human Cell Atlas ingest API hosted by the EBI for creation and management of HCA project submissions.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/unit/api/test_ingestapi_cache.py
+++ b/tests/unit/api/test_ingestapi_cache.py
@@ -1,0 +1,223 @@
+import uuid
+
+from mock import MagicMock, Mock
+from requests_cache import CachedSession
+from requests_mock import Adapter
+from unittest import TestCase
+
+from hca_ingest.api.ingestapi import IngestApi
+
+
+API_URL = "http://test.caching.ingest"
+SCHEMAS_URL = f'{API_URL}/schemas'
+SCHEMAS_RESPONSE = {
+    '_links': {
+        'schemas': {
+            'href': SCHEMAS_URL
+        }
+    }
+}
+
+
+class IngestApiCacheTest(TestCase):
+    def setUp(self):
+        self.token_manager = MagicMock()
+        self.token_manager.get_token = Mock(return_value='token')
+        self.adapter = Adapter()
+        self.register_mock_response('http://test.caching.ingest', SCHEMAS_RESPONSE)
+        session = self.mock_session(self.adapter)
+        self.api = IngestApi(url=API_URL, token_manager=self.token_manager, session=session)
+
+    def tearDown(self):
+        self.api.session.cache.clear()
+
+    @staticmethod
+    def mock_session(adapter):
+        # session will make mock requests where it would normally make real requests
+        session = CachedSession(backend='memory')
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        return session
+
+    def register_mock_response(self, uri, response, method='GET', status_code=200):
+        self.adapter.register_uri(
+            method,
+            uri,
+            headers={'Content-Type': 'application/json'},
+            json=response,
+            status_code=status_code,
+        )
+
+    def test_init_adds_to_cache(self):
+        self.assertTrue(self.api.session.cache.has_url(API_URL))
+
+    def test_schema_uses_cache(self):
+        # given
+        search_url = f'{SCHEMAS_URL}/search'
+        high_level = 'foo'
+        domain = 'barr'
+        concrete = 'wool'
+        mock_url = 'http://flibble'
+        schemas_get_url, latest_get_url = self.register_schema_responses(
+            search_url, high_level, domain, concrete, mock_url
+        )
+
+        # and given
+        self.assertFalse(self.api.session.cache.has_url(schemas_get_url))
+        self.assertFalse(self.api.session.cache.has_url(search_url))
+        self.assertFalse(self.api.session.cache.has_url(latest_get_url))
+
+        # when
+        result = self.api.get_latest_schema_url(high_level, domain, concrete)
+
+        # then
+        self.assertEqual(result, mock_url)
+        self.assertTrue(self.api.session.cache.has_url(schemas_get_url))
+        self.assertTrue(self.api.session.cache.has_url(search_url))
+        self.assertTrue(self.api.session.cache.has_url(latest_get_url))
+
+        # and then
+        self.assertTrue(self.api.get(schemas_get_url).from_cache)
+        self.assertTrue(self.api.get(search_url).from_cache)
+        self.assertTrue(self.api.get(latest_get_url).from_cache)
+
+    def test_patch_removes_item_from_cache(self):
+        self.removes_item_from_cache(self.api.patch, patch={})
+
+    def test_put_removes_item_from_cache(self):
+        self.removes_item_from_cache(self.api.put)
+
+    def test_post_removes_item_from_cache(self):
+        self.removes_item_from_cache(self.api.post)
+
+    def test_delete_removes_item_from_cache(self):
+        self.removes_item_from_cache(self.api.delete)
+
+    def test_new_item_clears_folder_cache(self):
+        # given
+        new_item = {
+            'uuid': {
+                'uuid': str(uuid.uuid4())
+            }
+        }
+        folder_url, item_url, search_url, search_all_url = self.register_item_responses()
+        self.register_mock_response(folder_url, new_item, method='POST', status_code=200)
+        self.prime_cache(folder_url, item_url, search_url, search_all_url)
+
+        # when
+        self.api.post(folder_url, json=new_item)
+
+        # then
+        self.assertFalse(self.api.session.cache.has_url(folder_url))
+
+    def removes_item_from_cache(self, action, **kwargs):
+        # given
+        folder_url, item_url, search_url, search_all_url = self.register_item_responses()
+        self.prime_cache(folder_url, item_url, search_url, search_all_url)
+
+        # when
+        action(item_url, **kwargs)
+
+        # then
+        self.assertFalse(self.api.session.cache.has_url(folder_url))
+        self.assertFalse(self.api.session.cache.has_url(item_url))
+        self.assertFalse(self.api.session.cache.has_url(search_url))
+        self.assertFalse(self.api.session.cache.has_url(search_all_url))
+
+    def register_item_responses(self, item_type='mocks', item_id='id', item_uuid=str(uuid.uuid4())):
+        folder_url = f'{API_URL}/{item_type}'
+        item_url = f'{folder_url}/{item_id}'
+        search_url = f'{folder_url}/search/findByUuid?uuid={item_uuid}'
+        search_all_url = f'{folder_url}/search/findAllByUuid?uuid={item_uuid}'
+
+        item = {
+            'uuid': {
+                'uuid': item_uuid
+            },
+            '_links': {
+                'self': {
+                    'href': item_url
+                }
+            }
+        }
+        folder = {
+            '_embedded': {
+                'item_type': [
+                    item
+                ]
+            }
+        }
+        self.register_mock_response(item_url, item)
+        self.register_mock_response(item_url, item, method='PUT', status_code=200)
+        self.register_mock_response(item_url, item, method='PATCH', status_code=200)
+        self.register_mock_response(item_url, item, method='POST', status_code=200)
+        self.register_mock_response(item_url, {}, method='DELETE', status_code=204)
+        self.register_mock_response(search_url, item)
+        self.register_mock_response(folder_url, folder)
+        self.register_mock_response(search_all_url, folder)
+        return folder_url, item_url, search_url, search_all_url
+
+    def prime_cache(self, *urls):
+        for url in urls:
+            self.api.get(url)
+            self.assertTrue(self.api.session.cache.has_url(url))
+
+    def register_schema_responses(self, search_url, high_level, domain, concrete, mock_url):
+        schemas_get_url = f'{SCHEMAS_URL}?size=1'
+        latest_url = f'{search_url}/latestSchemas'
+        latest_get_url = f'{latest_url}?size={self.api.page_size}'
+
+        self.register_mock_response(schemas_get_url, {
+            '_links': {
+                'search': {
+                    'href': search_url
+                }
+            }
+        })
+        self.register_mock_response(search_url, {
+            '_links': {
+                'latestSchemas': {
+                    'href': latest_url
+                }
+            }
+        })
+        self.register_mock_response(latest_get_url, {
+            '_embedded': {
+                'schemas': [
+                    {
+                        'highLevelEntity': f'not-{high_level}',
+                    },
+                    {
+                        'highLevelEntity': high_level,
+                        'domainEntity': f'not-{domain}',
+                    },
+                    {
+                        'highLevelEntity': high_level,
+                        'domainEntity': domain,
+                        'concreteEntity': f'not-{concrete}'
+                    },
+                    {
+                        'highLevelEntity': high_level,
+                        'domainEntity': domain,
+                        'concreteEntity': concrete,
+                        '_links': {
+                            'json-schema': {
+                                'href': mock_url
+                            }
+                        }
+                    },
+                    {
+                        'highLevelEntity': 'type',
+                        'domainEntity': 'project',
+                        'concreteEntity': 'project',
+                        '_links': {
+                            'json-schema': {
+                                'href': 'ignored'
+                            }
+                        }
+                    }
+                ]
+            },
+            '_links': {}
+        })
+        return schemas_get_url, latest_get_url


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#804

- [x] requests-cache
- [x] configurable page sizes
- [x] Update unit tests
- [x] manual synthetic tests
    
Cache Expiry:
- After 2 hours entries will become stale
- if any user of the client uses a PUT,PATCH,POST or DELETE method the entire cache is cleared.