### PR TITLE
DCP-844 Added get_user_projects function

### DIFF
--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -180,6 +180,10 @@ class IngestApi:
     def get_project_by_uuid(self, uuid):
         return self.get_entity_by_uuid('projects', uuid)
 
+    def get_user_projects(self):
+        user_project_url = f'{self.url}/user/projects'
+        return self.get_all(user_project_url, 'projects')
+
     def get_entity_by_uuid(self, entity_type, uuid):
         url = self.url + f'/{entity_type}/search/findByUuid?uuid=' + uuid
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as md:
 
 setup(
     name='hca-ingest',
-    version='2.1.0',
+    version='2.2.0',
     description='A library to communicate with the Human Cell Atlas ingest API hosted by the EBI for creation and management of HCA project submissions.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
For `hca_inges.api.IngestApi`:
- Added a function to retrieve all projects by a user, by using the `/user/projects` endpoint

This function requires the authorization headers to be set or will return a 401 exception, should I add some extra code to point out to "set_token" or "get_headers"?