### PR TITLE
dcp-858 Unit tests for polling

### DIFF
--- a/hca_ingest/api/ingestapi.py
+++ b/hca_ingest/api/ingestapi.py
@@ -7,7 +7,7 @@ import logging
 import os
 import time
 from urllib.parse import urljoin
-from polling import poll
+import polling
 
 import requests
 
@@ -32,7 +32,6 @@ class IngestApi:
         self._ingest_links = self._get_ingest_links()
         self.page_size = 100
         self.poll_step = 5
-        self.poll_timeout = 90
 
     def set_page_size(self, page_size):
         self.page_size = page_size
@@ -110,9 +109,7 @@ class IngestApi:
     def poll(self, url, **kwargs):
         if 'step' not in kwargs:
             kwargs['step'] = self.poll_step
-        if 'timeout' not in kwargs:
-            kwargs['timeout'] = self.poll_timeout
-        poll(lambda: self.get(url, bypass_cache=True), **kwargs)
+        polling.poll(lambda: self.get(url, bypass_cache=True), **kwargs)
 
     def _get_ingest_links(self):
         return self.get(self.url).json()["_links"]

--- a/hca_ingest/importer/importer.py
+++ b/hca_ingest/importer/importer.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Tuple, List
 
-import polling
 from openpyxl import Workbook
 from requests import HTTPError
 

--- a/hca_ingest/importer/importer.py
+++ b/hca_ingest/importer/importer.py
@@ -84,7 +84,12 @@ class XlsImporter:
             project = entity_map.get_project()
 
             if project and project_uuid and update_project:
-                self.ingest_api.poll(submission_url, check_sucess=self.ingest_api.is_response_editable)
+                self.ingest_api.poll(
+                    submission_url,
+                    step=5,
+                    timeout=90,
+                    check_success=self.ingest_api.is_response_editable
+                )
                 self.submitter.update_entity(project)
 
         except HTTPError as httpError:

--- a/hca_ingest/importer/importer.py
+++ b/hca_ingest/importer/importer.py
@@ -84,17 +84,8 @@ class XlsImporter:
 
             project = entity_map.get_project()
 
-            def is_editable(entity):
-                """check that the entity is readable"""
-                return entity['editable'] is True
-
             if project and project_uuid and update_project:
-                polling.poll(
-                    lambda: self.ingest_api.get(submission_url).json(),
-                    check_success=is_editable,
-                    step=5,
-                    timeout=90
-                )
+                self.ingest_api.poll(submission_url, check_sucess=self.ingest_api.is_response_editable)
                 self.submitter.update_entity(project)
 
         except HTTPError as httpError:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as md:
 
 setup(
     name='hca-ingest',
-    version='2.7.2',
+    version='2.7.3',
     description='A library to communicate with the Human Cell Atlas ingest API hosted by the EBI for creation and management of HCA project submissions.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/unit/api/test_ingestapi_cache.py
+++ b/tests/unit/api/test_ingestapi_cache.py
@@ -118,19 +118,14 @@ class IngestApiCacheTest(TestCase):
         # given
         test_id = str(uuid.uuid4()).replace('-', '')
         test_url = f'{API_URL}/BypassTest/{test_id}'
-        test_case_responses = [
-            {
-                'json': {
-                    'editable': False,
-                }
-            },
-            {
-                'json': {
-                    'editable': True,
-                }
-            }
-        ]
-        mock.get(test_url, test_case_responses)
+        first_response = {
+            'editable': False,
+        }
+        second_response = {
+            'editable': True,
+        }
+
+        mock.get(test_url, [{'json': first_response}, {'json': second_response}])
 
         # first_response
         self.assertFalse(self.api.is_response_editable(self.api.get(test_url)))
@@ -152,19 +147,15 @@ class IngestApiCacheTest(TestCase):
         # given
         test_id = str(uuid.uuid4()).replace('-', '')
         test_url = f'{API_URL}/BypassTest/{test_id}'
-        test_case_responses = [
-            {
-                'json': {
-                    'editable': False,
-                }
-            },
-            {
-                'json': {
-                    'editable': True,
-                }
-            }
-        ]
-        mock.get(test_url, test_case_responses)
+        first_response = {
+            'editable': False,
+        }
+        second_response = {
+            'editable': True,
+        }
+
+        mock.get(test_url, [{'json': first_response}, {'json': second_response}])
+
 
         # when
         self.api.poll(test_url, step=1, max_tries=2, check_success=self.api.is_response_editable)

--- a/tests/unit/api/test_ingestapi_cache.py
+++ b/tests/unit/api/test_ingestapi_cache.py
@@ -114,6 +114,40 @@ class IngestApiCacheTest(TestCase):
         # then
         self.assertFalse(self.api.session.cache.has_url(folder_url))
 
+    def test_bypass_cache_updates_cache(self, mock):
+        # given
+        test_uuid = str(uuid.uuid4())
+        test_id = str(uuid.uuid4()).replace('-', '')
+        test_url = f'{API_URL}/BypassTest/{test_id}'
+        test_case = {
+            'uuid': {
+                'uuid': test_uuid
+            },
+            'editable': False,
+            '_links': {
+                'self': {
+                    'href': test_url
+                }
+            }
+        }
+        mock.get(test_url, json=test_case)
+
+        # first_response
+        self.assertFalse(self.api.is_response_editable(self.api.get(test_url)))
+
+        # update source
+        test_case['editable'] = True
+        mock.get(test_url, json=test_case)
+
+        # cached_response still false
+        self.assertFalse(self.api.is_response_editable(self.api.get(test_url)))
+
+        # bypass_cache
+        self.assertTrue(self.api.is_response_editable(self.api.get(test_url, bypass_cache=True)))
+
+        # then cached result is updated
+        self.assertTrue(self.api.is_response_editable(self.api.get(test_url)))
+
     def removes_item_from_cache(self, mock: Mocker, action, **kwargs):
         # given
         folder_url, item_url, search_url, search_all_url = self.register_item_responses(mock)


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#858
ZenHub: dcp-858

- [x] Move polling feature into ingest api (easier to unit test)
- [x] fix import file unit tests
- [x] Add unit test for bypass_cache
- [x] Add unit tests for polling feature