### PR TITLE
Added better parsing domains for SchemaUrl.

### DIFF
--- a/hca_ingest/downloader/schema_url.py
+++ b/hca_ingest/downloader/schema_url.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-
+ACCEPTED_DOMAINS = ['biomaterial', 'protocol', 'process', 'file', 'project']
 
 @dataclass(unsafe_hash=True)
 class SchemaUrl:
@@ -11,4 +11,8 @@ class SchemaUrl:
 
     @property
     def domain_type(self):
-        return self.url.split('/')[4] if self.url else ''
+        try:
+            domain = ACCEPTED_DOMAINS[[domain in self.url for domain in ACCEPTED_DOMAINS].index(True)]
+            return domain
+        except ValueError:
+            return ''


### PR DESCRIPTION
Added better parsing for domains for SchemaUrl object

The old logic had harcoded domain ([4]), whereas this new logic will attempt to find one of the 5 domains accepted by our system (protocol, biomaterial, process, file or project)

I am not convinced this is the best logic, and if we are moving forward with custom schemas we will need to either:

- Specify this constraint anywhere ("Schemas need to be stored in a path that describes its entity type, and the entity types are currently limited to these")
- Review the necessity of providing the domain from the schemaUrl object (Will need revision of all the scripts/services that use this)

Fixes issue described here:

https://github.com/ebi-ait/dcp-ingest-central/issues/924