### PR TITLE
dcp942 correctly group by concrete entity type

### DIFF
--- a/hca_ingest/downloader/flattener.py
+++ b/hca_ingest/downloader/flattener.py
@@ -152,8 +152,12 @@ class Flattener:
 
     @staticmethod
     def __get_concrete_ids(input_entities: Iterable[Entity], core_name: str, id_name: str):
+
+        def sort_by_concrete_type(entity):
+            return entity.schema.concrete_type
         concrete_ids = {}
-        for concrete_type, inputs_iter in groupby(input_entities, lambda entity: entity.schema.concrete_type):
+        for concrete_type, inputs_iter in groupby(sorted(input_entities, key=sort_by_concrete_type),
+                                                  lambda entity: entity.schema.concrete_type):
             inputs = list(inputs_iter)
             input_ids = [i.content[core_name][id_name] for i in inputs]
             input_uuids = [i.uuid for i in inputs]


### PR DESCRIPTION
- Fixed Flattener in downloader module to correctly group by concrete schema types. Without sorting the list does not group properly.